### PR TITLE
Async indexing with concurrency limit (and progress callback)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1911,6 +1911,11 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+    },
     "exec-sh": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
@@ -5924,22 +5929,13 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
       "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true
-    },
-    "p-limit": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-      "requires": {
-        "p-try": "^2.0.0"
-      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -5967,10 +5963,22 @@
         }
       }
     },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    "p-queue": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.2.0.tgz",
+      "integrity": "sha512-B2LXNONcyn/G6uz2UBFsGjmSa0e/br3jznlzhEyCXg56c7VhEpiT2pZxGOfv32Q3FSyugAdys9KGpsv3kV+Sbg==",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "p-timeout": "^3.1.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
     },
     "pako": {
       "version": "1.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5934,12 +5934,11 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
@@ -5949,13 +5948,29 @@
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
       }
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
+    "p-limit": "^2.2.2",
     "pako": "^1.0.10",
     "ts-interface-checker": "^0.1.9"
   }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
-    "p-limit": "^2.2.2",
+    "p-queue": "6.2.0",
     "pako": "^1.0.10",
     "ts-interface-checker": "^0.1.9"
   }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -16,6 +16,7 @@ import { getCodec } from "../compression/creation";
 
 import pLimit from 'p-limit';
 
+// TODO: add similar optimizations for `Set`
 interface StoreGetOptions {
   concurrencyLimit?: number;
   progressCallback?: (progress: number) => void;


### PR DESCRIPTION
#### Rationale:
- Currently, each request is fetched synchronously, which doesn't exploit the browser's ability to make multiple requests concurrently.

#### Introduces:
- Asynchronous indexing of the zarr HTTPStore. 
- An`options` object as a parameter to `ZarrArray.get`. The `options` object exposes `concurrencyLimit` (limit of number of concurrent requests), and `progressCallback` (function which takes the current progress of the indexing 0 -> 1 as an argument) fields.

#### Usage:
```javascript
const z = await openArray(config);
const slice2d = await z.get([0, null, null], { 
        concurrencyLimit: 20, 
        progressCallback: progress => console.log(progress)
    }
);
```


I think there is something much cleaner to do with the `StoreGetOptions` interface, but I am fairly new to Typescript. Hoping you have some suggestions there!

I decided to use [`p-limit`](https://github.com/sindresorhus/p-limit) as it seems to be the most popular tool in this space (used by 3.8M) and is maintained actively. It also provides a nice way to get the number of items remaining in the queue, which I use.

For some reason optional chaining is was not working in typescript, so there are some rather ugly blocks performing checks for `null` and `undefined`. 