### PR TITLE
Add async setter with concurrency limit

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -490,6 +490,7 @@ export class ZarrArray {
       for (const _ of indexer.iter()) queueSize += 1;
 
       let progress = 0;
+      progressCallback({ progress: 0, queueSize: queueSize });
       for (const proj of indexer.iter()) {
         const chunkValue = this.getChunkValue(proj, indexer, value, selectionShape);
         (async () => {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -326,7 +326,7 @@ export class ZarrArray {
 
     }
 
-    // gaurantess that all work on queue has finished
+    // guarantees that all work on queue has finished
     await queue.onIdle();
 
     // Return scalar instead of zero-dimensional array.
@@ -509,7 +509,7 @@ export class ZarrArray {
 
     }
 
-    // gaurantess that all work on queue has finished
+    // guarantees that all work on queue has finished
     await queue.onIdle();
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -16,7 +16,7 @@ import { getCodec } from "../compression/creation";
 
 import PQueue from 'p-queue';
 
-interface GetOptions {
+export interface GetOptions {
   concurrencyLimit?: number;
   progressCallback?: (progressUpdate: {
     progress: number;
@@ -24,7 +24,7 @@ interface GetOptions {
   }) => void;
 }
 
-interface SetOptions {
+export interface SetOptions {
   concurrencyLimit?: number;
   progressCallback?: (progressUpdate: {
     progress: number;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,7 +6,7 @@ import { ZarrArrayMetadata, UserAttributes, FillType } from '../types';
 import { ARRAY_META_KEY, ATTRS_META_KEY } from '../names';
 import { Attributes } from "../attributes";
 import { parseMetadata } from "../metadata";
-import { ArraySelection, DimensionSelection, Indexer, Slice } from "./types";
+import { ArraySelection, DimensionSelection, Indexer, Slice, ChunkProjection } from "./types";
 import { BasicIndexer, isContiguousSelection } from './indexing';
 import { NestedArray } from "../nestedArray";
 import { TypedArray, DTYPE_TYPEDARRAY_MAPPING } from '../nestedArray/types';
@@ -16,8 +16,15 @@ import { getCodec } from "../compression/creation";
 
 import PQueue from 'p-queue';
 
-// TODO: add similar optimizations for `Set`
 interface GetOptions {
+  concurrencyLimit?: number;
+  progressCallback?: (progressUpdate: {
+    progress: number;
+    queueSize: number;
+  }) => void;
+}
+
+interface SetOptions {
   concurrencyLimit?: number;
   progressCallback?: (progressUpdate: {
     progress: number;
@@ -406,11 +413,11 @@ export class ZarrArray {
     return byteChunkData.buffer;
   }
 
-  public async set(selection: ArraySelection = null, value: any) {
-    await this.setBasicSelection(selection, value);
+  public async set(selection: ArraySelection = null, value: any, opts: SetOptions = {}) {
+    await this.setBasicSelection(selection, value, opts);
   }
 
-  public async setBasicSelection(selection: ArraySelection, value: any) {
+  public async setBasicSelection(selection: ArraySelection, value: any, { concurrencyLimit = 10, progressCallback }: SetOptions = {}) {
     if (this.readOnly) {
       throw new PermissionError("Object is read only");
     }
@@ -422,16 +429,32 @@ export class ZarrArray {
     if (this.shape === []) {
       throw new Error("Shape [] indexing is not supported yet");
     } else {
-      await this.setBasicSelectionND(selection, value);
+      await this.setBasicSelectionND(selection, value, concurrencyLimit, progressCallback);
     }
   }
 
-  private async setBasicSelectionND(selection: ArraySelection, value: any) {
+  private async setBasicSelectionND(selection: ArraySelection, value: any, concurrencyLimit: number, progressCallback?: (progressUpdate: { progress: number; queueSize: number }) => void) {
     const indexer = new BasicIndexer(selection, this);
-    await this.setSelection(indexer, value);
+    await this.setSelection(indexer, value, concurrencyLimit, progressCallback);
   }
 
-  private async setSelection(indexer: Indexer, value: number | NestedArray<TypedArray>) {
+  private getChunkValue(proj: ChunkProjection, indexer: Indexer, value: number | NestedArray<TypedArray>, selectionShape: number[]): number | NestedArray<TypedArray> {
+    let chunkValue: number | NestedArray<TypedArray>;
+    if (selectionShape === []) {
+      chunkValue = value;
+    } else if (typeof value === "number") {
+      chunkValue = value;
+    } else {
+      chunkValue = value.get(proj.outSelection);
+      // tslint:disable-next-line: strict-type-predicates
+      if (indexer.dropAxes !== null) {
+        throw new Error("Handling drop axes not supported yet");
+      }
+    }
+    return chunkValue;
+  }
+
+  private async setSelection(indexer: Indexer, value: number | NestedArray<TypedArray>, concurrencyLimit: number, progressCallback?: (progressUpdate: { progress: number; queueSize: number }) => void) {
     // We iterate over all chunks which overlap the selection and thus contain data
     // that needs to be replaced. Each chunk is processed in turn, extracting the
     // necessary data from the value array and storing into the chunk array.
@@ -459,24 +482,34 @@ export class ZarrArray {
       throw new Error("Unknown data type for setting :(");
     }
 
-    // Iterate over chunks in range
-    for (const proj of indexer.iter()) {
-      let chunkValue = null;
+    const queue = new PQueue({ concurrency: concurrencyLimit });
 
-      if (selectionShape === []) {
-        chunkValue = value;
-      } else if (typeof value === "number") {
-        chunkValue = value;
-      } else {
-        chunkValue = value.get(proj.outSelection);
-        // tslint:disable-next-line: strict-type-predicates
-        if (indexer.dropAxes !== null) {
-          throw new Error("Handling drop axes not supported yet");
-        }
+    if (progressCallback) {
+
+      let queueSize = 0;
+      for (const _ of indexer.iter()) queueSize += 1;
+
+      let progress = 0;
+      for (const proj of indexer.iter()) {
+        const chunkValue = this.getChunkValue(proj, indexer, value, selectionShape);
+        (async () => {
+          await queue.add(() => this.chunkSetItem(proj.chunkCoords, proj.chunkSelection, chunkValue));
+          progress += 1;
+          progressCallback({ progress: progress, queueSize: queueSize });
+        })();
       }
 
-      await this.chunkSetItem(proj.chunkCoords, proj.chunkSelection, chunkValue);
+    } else {
+
+      for (const proj of indexer.iter()) {
+        const chunkValue = this.getChunkValue(proj, indexer, value, selectionShape);
+        queue.add(() => this.chunkSetItem(proj.chunkCoords, proj.chunkSelection, chunkValue));
+      }
+
     }
+
+    // gaurantess that all work on queue has finished
+    await queue.onIdle();
   }
 
   private async chunkSetItem<T extends TypedArray>(chunkCoords: number[], chunkSelection: DimensionSelection[], value: number | NestedArray<TypedArray>) {

--- a/test/core/zarrArray.test.ts
+++ b/test/core/zarrArray.test.ts
@@ -2,7 +2,7 @@
 import { ZarrArray } from '../../src/core';
 import { ObjectStore } from '../../src/storage/objectStore';
 import { initArray, initGroup } from '../../src/storage';
-import { normalizeStoreArgument, CreateArrayOptionsWithoutShape } from '../../src/creation';
+import { normalizeStoreArgument, CreateArrayOptionsWithoutShape, zeros } from '../../src/creation';
 import { NestedArray, rangeTypedArray } from '../../src/nestedArray';
 import { slice } from '../../src/core/slice';
 import { arrayEquals1D } from '../../src/util';
@@ -72,7 +72,7 @@ describe("ZarrArray Creation", () => {
 
 describe("ZarrArray 1D Setting", () => {
 
-    it ("Can set 1D arrays", async() => {
+    it("Can set 1D arrays", async () => {
         const a = new NestedArray(null, 100, "<i4");
         const z = await createArray(a.shape, { chunks: 10, dtype: a.dtype });
         await z.set(null, a);
@@ -91,10 +91,22 @@ describe("ZarrArray 1D Setting", () => {
 
         const rangeTA = rangeTypedArray([35 - 15], Int32Array);
         const rangeNA = new NestedArray(rangeTA);
-        
+
         a.set(slice(15, 35), rangeNA);
         await z.set(slice(15, 35), rangeNA);
         expect(nestedArrayEquals(a, await z.get())).toBeTruthy();
+    });
+});
+
+describe("ZarrArray Set with progress callback", () => {
+    it("calls the callback the right amount of times with progress", async () => {
+        const cb = jest.fn();
+        const z = await zeros([5, 100], { chunks: [1, 50] });
+        await z.set(null, 1, { progressCallback: cb });
+        expect(cb.mock.calls.length).toBe(10 + 1);
+        expect(cb.mock.calls[0][0]).toEqual({ progress: 0, queueSize: 10 });
+        expect(cb.mock.calls[5][0]).toEqual({ progress: 5, queueSize: 10 });
+        expect(cb.mock.calls[10][0]).toEqual({ progress: 10, queueSize: 10 });
     });
 });
 


### PR DESCRIPTION
Similar to #11, allows user to write to store asynchronously. Uses [`p-queue`](https://github.com/sindresorhus/p-queue) to handle concurrency. 


### Usage
```javascript
const a = new NestedArray(null, 100, "<i4");
const z = await createArray(a.shape, { chunks: 10, dtype: a.dtype });

const setterConfig = { 
    concurrencyLimit: 10, //default
    progressCallback: ({ progress, queueSize }) => console.log(progress/queueSize),
} 
await z.set(null, a, setterConfig);
```

Before merging this, I think we should add tests for both the callback implemented in #11 and here.