### PR TITLE
Fix node check for webworkers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     },
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-        "project": "tsconfig.json",
+        "project": "tsconfig.eslint.json",
         "sourceType": "module"
     },
     "plugins": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zarr",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zarr",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "",
   "keywords": [],
   "main": "dist/zarr.umd.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint src/**/*.ts test/**/*.ts test/**/*.js",
     "prebuild": "rimraf dist",
     "build": "tsc && rollup -c rollup.config.ts",
     "start": "rollup -c rollup.config.ts -w",

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,5 +1,6 @@
 import { ZarrMetadataType, UserAttributes } from './types';
 import { ValidStoreType } from './storage/types';
+import { IS_NODE } from './util';
 
 export function parseMetadata(
     s: ValidStoreType | ZarrMetadataType
@@ -10,7 +11,7 @@ export function parseMetadata(
     // all groups and arrays will already have been parsed from JSON.
     if (typeof s !== 'string') {
         // tslint:disable-next-line: strict-type-predicates
-        if (typeof window === 'undefined' && Buffer.isBuffer(s)) {
+        if (IS_NODE && Buffer.isBuffer(s)) {
             return JSON.parse(s.toString());
         } else if (s instanceof ArrayBuffer) {
             // Note, could use a TextDecoder here if we drop support for Edge (much faster)

--- a/src/nestedArray/index.ts
+++ b/src/nestedArray/index.ts
@@ -3,7 +3,7 @@ import { NestedArrayData, TypedArray, TypedArrayConstructor, DTYPE_TYPEDARRAY_MA
 import { ArraySelection, Slice } from '../core/types';
 import { slice } from '../core/slice';
 import { ValueError } from '../errors';
-import { normalizeShape } from '../util';
+import { normalizeShape, IS_NODE } from '../util';
 import { setNestedArray, setNestedArrayToScalar, flattenNestedArray, sliceNestedArray } from './ops';
 
 export class NestedArray<T extends TypedArray> {
@@ -44,7 +44,7 @@ export class NestedArray<T extends TypedArray> {
         }
         else if (
             // tslint:disable-next-line: strict-type-predicates
-            (typeof window === 'undefined' && Buffer.isBuffer(data))
+            (IS_NODE && Buffer.isBuffer(data))
             || data instanceof ArrayBuffer
             || data === null
             || data.toString().startsWith("[object ArrayBuffer]") // Necessary for Node.js for some reason..

--- a/src/storage/httpStore.ts
+++ b/src/storage/httpStore.ts
@@ -1,4 +1,5 @@
 import { ValidStoreType, AsyncStore } from './types';
+import { IS_NODE } from '../util';
 
 export class HTTPStore implements AsyncStore<ArrayBuffer> {
     listDir?: undefined;
@@ -19,8 +20,7 @@ export class HTTPStore implements AsyncStore<ArrayBuffer> {
     async getItem(item: string) {
         const url = new URL(item, this.url).href;
         const value = await fetch(url);
-        // tslint:disable-next-line: strict-type-predicates
-        if (typeof window === 'undefined') {
+        if (IS_NODE) {
             // Node
             return Buffer.from(await value.arrayBuffer());
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,17 @@
-export type ZarrMetadataType = ZarrArrayMetadata | ZarrGroupMetadata
-export type UserAttributes = object
+export type ZarrMetadataType = ZarrArrayMetadata | ZarrGroupMetadata;
+export type UserAttributes = object;
 
 /**
  * A scalar value providing the default value to use for uninitialized portions of the array, or `null` if no fill_value is to be used.
  */
-export type FillType = number | null
+export type FillType = number | null;
 
-export type FillTypeSerialized = number | 'NaN' | 'Infinity' | '-Infinity' | null
+export type FillTypeSerialized = number | 'NaN' | 'Infinity' | '-Infinity' | null;
 
 /**
  * Either `"C"` or `"F"`, defining the layout of bytes within each chunk of the array. `“C”` means row-major order, i.e., the last dimension varies fastest; `“F”` means column-major order, i.e., the first dimension varies fastest.
  */
-export type Order = 'C' | 'F'
+export type Order = 'C' | 'F';
 /**
  * Currently supported dtypes are listed here only.
  */
@@ -25,7 +25,7 @@ export type DtypeString =
   | '<f4'
   | '<f8'
   | '<b'
-  | '<B'
+  | '<B';
 
 /**
  * User interface for chunking.
@@ -35,37 +35,37 @@ export type DtypeString =
  *   - `number > 0`: Chunks of given size along dimension.
  *   - `null` or `-1`: No chunking along this dimension.
  */
-export type ChunksArgument = number | (number | null)[] | boolean | null
+export type ChunksArgument = number | (number | null)[] | boolean | null;
 
 export interface CompressorConfig {
-  id: string
+  id: string;
 }
 export interface Filter {
-  id: string
+  id: string;
 }
 
 export interface ZarrArrayMetadata {
   /**
    * An integer defining the version of the storage specification to which the array store adheres.
    */
-  zarr_format: 1 | 2
+  zarr_format: 1 | 2;
 
   /**
    * A list of integers defining the length of each dimension of the array.
    */
-  shape: number[]
+  shape: number[];
 
   /**
    * A list of integers defining the length of each dimension of a chunk of the array. Note that all chunks within a Zarr array have the same shape.
    */
-  chunks: number[]
+  chunks: number[];
 
   /**
    * A string or list defining a valid data type for the array. See https://zarr.readthedocs.io/en/stable/spec/v2.html#data-type-encoding.
    * Lists are not supported yet
    * Only a subset of types are supported in this library (for now), see the docs.
    */
-  dtype: DtypeString // | DtypeString[];
+  dtype: DtypeString; // | DtypeString[];
 
   /**
    * A JSON object identifying the primary compression codec and providing configuration parameters, or null if no compressor is to be used. The object MUST contain an "id" key identifying the codec to be used.
@@ -73,30 +73,30 @@ export interface ZarrArrayMetadata {
   compressor:
     | null
     | ({
-        id: string
-      } & any)
+        id: string;
+      } & any);
 
   /**
    * A scalar value providing the default value to use for uninitialized portions of the array, or `null` if no fill_value is to be used.
    */
-  fill_value: FillTypeSerialized
+  fill_value: FillTypeSerialized;
 
   /**
    * Either `"C"` or `"F"`, defining the layout of bytes within each chunk of the array. `“C”` means row-major order, i.e., the last dimension varies fastest; `“F”` means column-major order, i.e., the first dimension varies fastest.
    */
-  order: Order
+  order: Order;
 
   /**
    * A list of JSON objects providing codec configurations, or `null` if no filters are to be applied. Each codec configuration object MUST contain a `"id"` key identifying the codec to be used.
    */
-  filters: null | Filter[]
+  filters: null | Filter[];
 }
 
 export interface ZarrGroupMetadata {
   /**
    * An integer defining the version of the storage specification to which the array store adheres.
    */
-  zarr_format: 1 | 2
+  zarr_format: 1 | 2;
 }
 
 /**
@@ -107,4 +107,4 @@ export interface ZarrGroupMetadata {
  * * 'w' means create (overwrite if exists);
  * * 'w-' means create (fail if exists).
  */
-export type PersistenceMode = 'r' | 'r+' | 'a' | 'w' | 'w-'
+export type PersistenceMode = 'r' | 'r+' | 'a' | 'w' | 'w-';

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,6 +7,11 @@ import { isSlice } from "./core/indexing";
 
 const TypeCheckSuite = createCheckers(typesTI);
 
+/**
+ * This should be true only if this javascript is getting executed in Node.
+ */
+export const IS_NODE = typeof process !== "undefined" && process.versions && process.versions.node;
+
 export function humanReadableSize(size: number) {
     if (size < 2 ** 10) {
         return `${size}`;

--- a/test/globalSetup.js
+++ b/test/globalSetup.js
@@ -1,9 +1,10 @@
-const { setup: setupDevServer } = require('jest-dev-server')
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { setup: setupDevServer } = require('jest-dev-server');
 
 module.exports = async function globalSetup() {
   await setupDevServer({
     command: 'node fixtures-server.js',
     port: 7357,
     debug: true,
-  })
-}
+  });
+};

--- a/test/globalTeardown.js
+++ b/test/globalTeardown.js
@@ -1,6 +1,6 @@
-// global-teardown.js
-const { teardown: teardownDevServer } = require('jest-dev-server')
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { teardown: teardownDevServer } = require('jest-dev-server');
 
 module.exports = async function globalTeardown() {
-    await teardownDevServer()
-}
+    await teardownDevServer();
+};

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,6 +1,13 @@
 
 import * as util from "../src/util";
 
+describe("Node check", () => {
+    it("detects that the tests run in Node", () => {
+        expect(util.IS_NODE).toBeTruthy();
+    });
+});
+
+
 describe("Human Readable Size", () => {
     it("describes values as expected", () => {
         expect(util.humanReadableSize(100)).toEqual("100");

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,13 @@
+{
+    // extend the base config, this file is required for eslint to also lint the tests and not complain.
+    "extends": "./tsconfig.json",
+    "include": [
+      "src/**/*.ts",
+      "test/**/*.ts",
+      "test/**/*.js"
+    ],
+    "compilerOptions": {
+      "allowJs": true,
+      "checkJs": true
+    }
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
     ]
   },
   "include": [
-    "src",
-    "test"
+    "src"
   ]
 }


### PR DESCRIPTION
Should fix #18 

Ended up also fixing the linting of tests. Before we would also build the test files into `dist`, which was not desirable, removing that broke the linting.