### PR TITLE
add `ZarrStore.getRaw`

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -373,12 +373,12 @@ export class ZarrArray {
         if (out instanceof NestedArray) {
           out.set(outSelection, this.toNestedArray<T>(this.decodeChunk(await cdata)));
         } else {
-          out.set(outSelection, this.toTypedArray(this.decodeChunk(await cdata)));
+          out.set(outSelection, this.toRawArray(this.decodeChunk(await cdata)));
         }
         return;
       }
       if (out instanceof RawArray) {
-        out.set(outSelection, this.toTypedArray(this.decodeChunk(await cdata)));
+        out.set(outSelection, this.toRawArray(this.decodeChunk(await cdata)));
       }
       // Decode chunk
       const chunk = this.toNestedArray(this.decodeChunk(await cdata));
@@ -414,6 +414,11 @@ export class ZarrArray {
 
   private toTypedArray(buffer: Buffer | ArrayBuffer) {
     return new DTYPE_TYPEDARRAY_MAPPING[this.dtype](buffer);
+  }
+
+  private toRawArray(buffer: Buffer | ArrayBuffer) {
+    console.log(this.chunks);
+    return new RawArray(buffer, this.chunks, this.dtype);
   }
 
   private toNestedArray<T extends TypedArray>(data: ValidStoreType) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -256,21 +256,26 @@ export class ZarrArray {
     }
   }
 
-  public get(selection?: undefined | Slice | ":" | "..." | null | (Slice | null | ":" | "...")[], opts?: GetOptions): Promise<NestedArray<TypedArray>>;
+  public get(selection?: undefined | Slice | ":" | "..." | null | (Slice | null | ":" | "...")[], opts?: GetOptions): Promise<NestedArray<TypedArray> | number>;
   public get(selection?: ArraySelection, opts?: GetOptions): Promise<NestedArray<TypedArray> | number>;
-  public get(selection: ArraySelection = null, opts: GetOptions = {}): Promise<NestedArray<TypedArray> | RawArray | number> {
+  public get(selection: ArraySelection = null, opts: GetOptions = {}): Promise<NestedArray<TypedArray> | number> {
     return this.getBasicSelection(selection, false, opts);
   }
 
-  public getRaw(selection?: undefined | Slice | ":" | "..." | null | (Slice | null | ":" | "...")[], opts?: GetOptions): Promise<RawArray>;
+  public getRaw(selection?: undefined | Slice | ":" | "..." | null | (Slice | null | ":" | "...")[], opts?: GetOptions): Promise<RawArray | number>;
   public getRaw(selection?: ArraySelection, opts?: GetOptions): Promise<RawArray | number>;
-  public getRaw(selection: ArraySelection = null, opts: GetOptions = {}): Promise<NestedArray<TypedArray> | RawArray | number> {
+  public getRaw(selection: ArraySelection = null, opts: GetOptions = {}): Promise<RawArray | number> {
     return this.getBasicSelection(selection, true, opts);
   }
 
-  public async getBasicSelection(selection: Slice | ":" | "..." | null | (Slice | null | ":" | "...")[], asRaw?: boolean, opts?: GetOptions): Promise<NestedArray<TypedArray> | RawArray>;
-  public async getBasicSelection(selection: ArraySelection, asRaw?: boolean, opts?: GetOptions): Promise<NestedArray<TypedArray> | number | RawArray>;
-  public async getBasicSelection(selection: ArraySelection, asRaw = false, { concurrencyLimit = 10, progressCallback }: GetOptions = {}): Promise<number | NestedArray<TypedArray> | RawArray> {
+  // asRaw = false
+  public async getBasicSelection(selection: Slice | ":" | "..." | null | (Slice | null | ":" | "...")[], asRaw?: false, opts?: GetOptions): Promise<NestedArray<TypedArray> | number>;
+  public async getBasicSelection(selection: ArraySelection, asRaw?: false, opts?: GetOptions): Promise<NestedArray<TypedArray> | number>;
+  // asRaw = true
+  public async getBasicSelection(selection: Slice | ":" | "..." | null | (Slice | null | ":" | "...")[], asRaw?: true, opts?: GetOptions): Promise<RawArray | number>;
+  public async getBasicSelection(selection: ArraySelection, asRaw?: true, opts?: GetOptions): Promise<RawArray | number>;
+
+  public async getBasicSelection(selection: ArraySelection, asRaw = false, { concurrencyLimit = 10, progressCallback }: GetOptions = {}): Promise<NestedArray<TypedArray> | RawArray | number> {
     // Refresh metadata
     if (!this.cacheMetadata) {
       await this.reloadMetadata();

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -373,7 +373,7 @@ export class ZarrArray {
         if (out instanceof NestedArray) {
           out.set(outSelection, this.toNestedArray<T>(this.decodeChunk(await cdata)));
         } else {
-          out.set(outSelection, chunkSelection, this.toRawArray(this.decodeChunk(await cdata)));
+          out.set(outSelection, this.toRawArray(this.decodeChunk(await cdata)), chunkSelection);
         }
         return;
       }
@@ -391,7 +391,7 @@ export class ZarrArray {
           out.set(outSelection, tmp as NestedArray<T>);
         }
       } else {
-        out.set(outSelection, chunkSelection, this.toRawArray(this.decodeChunk(await cdata)));
+        out.set(outSelection, this.toRawArray(this.decodeChunk(await cdata)), chunkSelection);
       }
 
     } else { // Chunk isn't there, use fill value

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -339,7 +339,7 @@ export class ZarrArray {
     await queue.onIdle();
 
     // Return scalar instead of zero-dimensional array.
-    if (out instanceof NestedArray && out.shape.length === 0) {
+    if (out.shape.length === 0) {
       return out.data[0] as number;
     }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -310,9 +310,9 @@ export class ZarrArray {
       const proj = itr.next(); // make sure there is only one projection
       if (proj.done === false && itr.next().done === true) {
         const chunkProjection = proj.value as ChunkProjection;
-        this.decodeDirectToRawArray(chunkProjection, outShape, outSize);
+        const out = await this.decodeDirectToRawArray(chunkProjection, outShape, outSize);
+        return out;
       }
-
     }
 
     const out = asRaw

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -373,7 +373,7 @@ export class ZarrArray {
         if (out instanceof NestedArray) {
           out.set(outSelection, this.toNestedArray<T>(this.decodeChunk(await cdata)));
         } else {
-          out.set(outSelection, chunkSelection.filter(d => !(typeof (d) === "number")), this.toRawArray(this.decodeChunk(await cdata)));
+          out.set(outSelection, chunkSelection, this.toRawArray(this.decodeChunk(await cdata)));
         }
         return;
       }
@@ -391,7 +391,7 @@ export class ZarrArray {
           out.set(outSelection, tmp as NestedArray<T>);
         }
       } else {
-        out.set(outSelection, chunkSelection.filter(d => !(typeof (d) === "number")), this.toRawArray(this.decodeChunk(await cdata)));
+        out.set(outSelection, chunkSelection, this.toRawArray(this.decodeChunk(await cdata)));
       }
 
     } else { // Chunk isn't there, use fill value
@@ -419,8 +419,7 @@ export class ZarrArray {
   }
 
   private toRawArray(buffer: Buffer | ArrayBuffer) {
-    const shape = this.chunks.filter(i => i !== 1); // if chunk is (1,3,2), shape of resulting arr is (3,2)
-    return new RawArray(buffer, shape, this.dtype);
+    return new RawArray(buffer, this.chunks, this.dtype);
   }
 
   private toNestedArray<T extends TypedArray>(data: ValidStoreType) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -375,12 +375,11 @@ export class ZarrArray {
         } else {
           out.set(outSelection, this.toTypedArray(this.decodeChunk(await cdata)));
         }
-        console.log(cKey);
         return;
       }
-      console.log(cKey);
-      console.log(outSelection);
-      // out.set(outSelection, this.toTypedArray(this.decodeChunk(await cdata)));
+      if (out instanceof RawArray) {
+        out.set(outSelection, this.toTypedArray(this.decodeChunk(await cdata)));
+      }
       // Decode chunk
       const chunk = this.toNestedArray(this.decodeChunk(await cdata));
       const tmp = chunk.get(chunkSelection);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -375,8 +375,10 @@ export class ZarrArray {
         } else {
           out.set(outSelection, this.toTypedArray(this.decodeChunk(await cdata)));
         }
+        console.log(cKey);
         return;
       }
+      console.log(cKey);
       console.log(outSelection);
       // out.set(outSelection, this.toTypedArray(this.decodeChunk(await cdata)));
       // Decode chunk

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -387,18 +387,15 @@ export class ZarrArray {
           throw new Error("Drop axes is not supported yet");
         }
 
-        if (out instanceof NestedArray) {
-          out.set(outSelection, tmp as NestedArray<T>);
-        }
+        out.set(outSelection, tmp as NestedArray<T>);
+
       } else {
         out.set(outSelection, this.toRawArray(this.decodeChunk(await cdata)), chunkSelection);
       }
 
     } else { // Chunk isn't there, use fill value
       if (this.fillValue !== null) {
-        if (out instanceof NestedArray) {
-          out.set(outSelection, this.fillValue);
-        }
+        out.set(outSelection, this.fillValue);
       }
     }
   }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -309,10 +309,10 @@ export class ZarrArray {
     const outSize = indexer.shape.reduce((x, y) => x * y, 1);
 
     if (asRaw && (outSize === this.chunkSize)) {
-      // Optimization if output strided array _is_ chunk exactly
-      // Decode directly as new TypedArray and return
+      // Optimization: if output strided array _is_ chunk exactly,
+      // decode directly as new TypedArray and return
       const itr = indexer.iter();
-      const proj = itr.next(); // make sure there is only one projection
+      const proj = itr.next(); // ensure there is only one projection
       if (proj.done === false && itr.next().done === true) {
         const chunkProjection = proj.value as ChunkProjection;
         const out = await this.decodeDirectToRawArray(chunkProjection, outShape, outSize);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -373,10 +373,12 @@ export class ZarrArray {
         if (out instanceof NestedArray) {
           out.set(outSelection, this.toNestedArray<T>(this.decodeChunk(await cdata)));
         } else {
-          out.set(outSelection, this.decodeChunk(await cdata));
+          out.set(outSelection, this.toTypedArray(this.decodeChunk(await cdata)));
         }
         return;
       }
+      console.log(outSelection);
+      // out.set(outSelection, this.toTypedArray(this.decodeChunk(await cdata)));
       // Decode chunk
       const chunk = this.toNestedArray(this.decodeChunk(await cdata));
       const tmp = chunk.get(chunkSelection);

--- a/src/nestedArray/ops.ts
+++ b/src/nestedArray/ops.ts
@@ -20,7 +20,7 @@ export function getNestedArrayConstructor<T extends TypedArray>(arr: any): Typed
  * Returns both the slice result and new output shape
  * @param arr NestedArray to slice
  * @param shape The shape of the NestedArray
- * @param selection 
+ * @param selection
  */
 export function sliceNestedArray<T extends TypedArray>(arr: NestedArrayData, shape: number[], selection: number | ArraySelection): [NestedArrayData | number, number[]] {
     // This translates "...", ":", null into a list of slices or integer selections
@@ -129,11 +129,10 @@ function _setNestedArray<T extends TypedArray>(dstArr: NestedArrayData, sourceAr
     if (shape.length === 1) {
         if (step === 1) {
             (dstArr as TypedArray).set(sourceArr as TypedArray, from);
-            return;
-        }
-
-        for (let i = 0; i < outputSize; i++) {
-            dstArr[from + i * step] = (sourceArr)[i];
+        } else {
+            for (let i = 0; i < outputSize; i++) {
+                dstArr[from + i * step] = (sourceArr)[i];
+            }
         }
         return;
     }
@@ -151,11 +150,10 @@ function _setNestedArrayToScalar<T extends TypedArray>(dstArr: NestedArrayData, 
     if (shape.length === 1) {
         if (step === 1) {
             (dstArr as TypedArray).fill(value, from, to);
-            return;
-        }
-
-        for (let i = 0; i < outputSize; i++) {
-            dstArr[from + i * step] = value;
+        } else {
+            for (let i = 0; i < outputSize; i++) {
+                dstArr[from + i * step] = value;
+            }
         }
         return;
     }

--- a/src/nestedArray/types.ts
+++ b/src/nestedArray/types.ts
@@ -29,11 +29,11 @@ export type TypedArray =
 //     constructor: TypedArrayConstructor<TypedArray>;
 // };
 export type TypedArrayConstructor<TypedArray> = {
-  new (): TypedArray;
+  new(): TypedArray;
   // tslint:disable-next-line: unified-signatures
-  new (size: number): TypedArray;
+  new(size: number): TypedArray;
   // tslint:disable-next-line: unified-signatures
-  new (buffer: ArrayBuffer): TypedArray;
+  new(buffer: ArrayBuffer): TypedArray;
   BYTES_PER_ELEMENT: number;
 };
 

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -1,19 +1,15 @@
 import { DtypeString } from '../types';
-import { ArraySelection, Slice } from '../core/types';
+import { ArraySelection } from '../core/types';
 import { slice } from '../core/slice';
 import { ValueError } from '../errors';
 import { normalizeShape, IS_NODE } from '../util';
 import { TypedArray, DTYPE_TYPEDARRAY_MAPPING, getTypedArrayDtypeString, TypedArrayConstructor } from '../nestedArray/types';
 
-// private setTypedArray(outSelection: DimensionSelection[], dstArr: TypedArray, value: TypedArray | number) {
-//     return;
-//     // dstArr.fill(value, from, to);
-//   }
 
 export class RawArray {
     dtype: DtypeString;
     shape: number[];
-    data: TypedArray;
+    data!: TypedArray;
 
     constructor(data: TypedArray, shape?: number | number[], dtype?: DtypeString)
     constructor(data: Buffer | ArrayBuffer | null, shape: number | number[], dtype: DtypeString)
@@ -40,9 +36,7 @@ export class RawArray {
 
         if (dataIsTypedArray && shape.length !== 1) {
             data = (data as TypedArray).buffer;
-        }
-
-        else if (
+        } else if (
             // tslint:disable-next-line: strict-type-predicates
             (IS_NODE && Buffer.isBuffer(data))
             || data instanceof ArrayBuffer
@@ -61,8 +55,7 @@ export class RawArray {
                 throw new Error(`Buffer has ${numDataElements} of dtype ${dtype}, shape is too large or small ${shape} (flat=${numShapeElements})`);
             }
             const typeConstructor: TypedArrayConstructor<TypedArray> = DTYPE_TYPEDARRAY_MAPPING[dtype];
-            const size = shape.reduce((x, y) => x * y, 1);
-            this.data = new typeConstructor(size);
+            this.data = new typeConstructor(numShapeElements);
         } else {
             this.data = data;
         }
@@ -77,11 +70,14 @@ export class RawArray {
                 // Zero dimension array..
                 this.data[0] = value;
             } else {
-                setNestedArrayToScalar(this.data, value, this.shape, selection);
+                // setNestedArrayToScalar(this.data, value, this.shape, selection);
+                console.log(selection, "number");
             }
         } else {
-            setNestedArray(this.data, value.data, this.shape, value.shape, selection);
+            // setRawArray(this.data, value, this.shape, selection);
+            console.log(selection);
         }
+
     }
 }
 

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -2,14 +2,14 @@ import { DtypeString } from '../types';
 import { ArraySelection } from '../core/types';
 import { slice } from '../core/slice';
 import { ValueError } from '../errors';
-import { normalizeShape, IS_NODE } from '../util';
+import { normalizeShape, IS_NODE, getStrides } from '../util';
 import { TypedArray, DTYPE_TYPEDARRAY_MAPPING, getTypedArrayDtypeString, TypedArrayConstructor } from '../nestedArray/types';
 import { setRawArray } from './ops';
 
 export class RawArray {
     dtype: DtypeString;
     shape: number[];
-    stride: number[];
+    strides: number[];
     data!: TypedArray;
 
     constructor(data: TypedArray, shape?: number | number[], dtype?: DtypeString, stride?: number[])
@@ -35,15 +35,10 @@ export class RawArray {
         this.shape = shape;
         this.dtype = dtype;
 
-        if (stride === undefined) {
-            const d = shape.length;
-            stride = new Array(d);
-            for (let i = d - 1, sz = 1; i >= 0; --i) {
-                stride[i] = sz;
-                sz *= shape[i];
-            }
+        if (strides === undefined) {
+            strides = getStrides(shape);
         }
-        this.stride = stride;
+        this.strides = strides;
 
         if (dataIsTypedArray && shape.length !== 1) {
             data = (data as TypedArray).buffer;

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -13,7 +13,7 @@ export class RawArray {
     data: TypedArray;
 
     constructor(data: TypedArray, shape?: number | number[], dtype?: DtypeString, strides?: number[])
-    constructor(data: Buffer | ArrayBuffer | null, shape: number | number[], dtype: DtypeString, strides?: number[])
+    constructor(data: Buffer | ArrayBuffer | null, shape?: number | number[], dtype?: DtypeString, strides?: number[])
     constructor(data: Buffer | ArrayBuffer | TypedArray | null, shape?: number | number[], dtype?: DtypeString, strides?: number[]) {
         const dataIsTypedArray = data !== null && !!(data as TypedArray).BYTES_PER_ELEMENT;
 

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -1,0 +1,88 @@
+import { DtypeString } from '../types';
+import { ArraySelection, Slice } from '../core/types';
+import { slice } from '../core/slice';
+import { ValueError } from '../errors';
+import { normalizeShape, IS_NODE } from '../util';
+import { TypedArray, DTYPE_TYPEDARRAY_MAPPING, getTypedArrayDtypeString, TypedArrayConstructor } from '../nestedArray/types';
+
+// private setTypedArray(outSelection: DimensionSelection[], dstArr: TypedArray, value: TypedArray | number) {
+//     return;
+//     // dstArr.fill(value, from, to);
+//   }
+
+export class RawArray {
+    dtype: DtypeString;
+    shape: number[];
+    data: TypedArray;
+
+    constructor(data: TypedArray, shape?: number | number[], dtype?: DtypeString)
+    constructor(data: Buffer | ArrayBuffer | null, shape: number | number[], dtype: DtypeString)
+    constructor(data: Buffer | ArrayBuffer | TypedArray | null, shape?: number | number[], dtype?: DtypeString) {
+        const dataIsTypedArray = data !== null && !!(data as TypedArray).BYTES_PER_ELEMENT;
+
+        if (shape === undefined) {
+            if (!dataIsTypedArray) {
+                throw new ValueError("Shape argument is required unless you pass in a TypedArray");
+            }
+            shape = [(data as TypedArray).length];
+        }
+
+        if (dtype === undefined) {
+            if (!dataIsTypedArray) {
+                throw new ValueError("Dtype argument is required unless you pass in a TypedArray");
+            }
+            dtype = getTypedArrayDtypeString(data as TypedArray);
+        }
+
+        shape = normalizeShape(shape);
+        this.shape = shape;
+        this.dtype = dtype;
+
+        if (dataIsTypedArray && shape.length !== 1) {
+            data = (data as TypedArray).buffer;
+        }
+
+        else if (
+            // tslint:disable-next-line: strict-type-predicates
+            (IS_NODE && Buffer.isBuffer(data))
+            || data instanceof ArrayBuffer
+            || data === null
+            || data.toString().startsWith("[object ArrayBuffer]") // Necessary for Node.js for some reason..
+        ) {
+            // Create from ArrayBuffer or Buffer
+            const numShapeElements = shape.reduce((x, y) => x * y, 1);
+
+            if (data === null) {
+                data = new ArrayBuffer(numShapeElements * parseInt(dtype[dtype.length - 1], 10));
+            }
+
+            const numDataElements = (data as ArrayBuffer).byteLength / parseInt(dtype[dtype.length - 1], 10);
+            if (numShapeElements !== numDataElements) {
+                throw new Error(`Buffer has ${numDataElements} of dtype ${dtype}, shape is too large or small ${shape} (flat=${numShapeElements})`);
+            }
+            const typeConstructor: TypedArrayConstructor<TypedArray> = DTYPE_TYPEDARRAY_MAPPING[dtype];
+            const size = shape.reduce((x, y) => x * y, 1);
+            this.data = new typeConstructor(size);
+        } else {
+            this.data = data;
+        }
+    }
+
+    public set(selection: ArraySelection = null, value: ArrayBuffer | number) {
+        if (selection === null) {
+            selection = [slice(null)];
+        }
+        if (typeof value === "number") {
+            if (this.shape.length === 0) {
+                // Zero dimension array..
+                this.data[0] = value;
+            } else {
+                setNestedArrayToScalar(this.data, value, this.shape, selection);
+            }
+        } else {
+            setNestedArray(this.data, value.data, this.shape, value.shape, selection);
+        }
+    }
+}
+
+

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -72,7 +72,7 @@ export class RawArray {
         }
     }
 
-    public set(selection: ArraySelection = null, value: RawArray) {
+    public set(selection: ArraySelection = null, sourceSelection: ArraySelection, value: RawArray | number) {
         if (selection === null) {
             selection = [slice(null)];
         }
@@ -85,7 +85,7 @@ export class RawArray {
                 this.data.fill(value);
             }
         } else {
-            setRawArray(this.data, this.strides, value.data, value.strides, this.shape, selection);
+            setRawArray(this.data, this.strides, this.shape, selection, value.data, value.strides, value.shape, sourceSelection);
         }
     }
 }

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -4,7 +4,7 @@ import { slice } from '../core/slice';
 import { ValueError } from '../errors';
 import { normalizeShape, IS_NODE, getStrides } from '../util';
 import { TypedArray, DTYPE_TYPEDARRAY_MAPPING, getTypedArrayDtypeString, TypedArrayConstructor } from '../nestedArray/types';
-import { setRawArrayDirect } from './ops';
+import { setRawArrayDirect, setRawArrayToScalar } from './ops';
 
 export class RawArray {
     dtype: DtypeString;
@@ -82,7 +82,7 @@ export class RawArray {
                 // Zero dimension array..
                 this.data[0] = value;
             } else {
-                this.data.fill(value);
+                setRawArrayToScalar(this.data, this.strides, this.shape, selection, value);
             }
         } else if (sourceSelection) {
             // Copy directly from decoded chunk to destination array

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -12,9 +12,9 @@ export class RawArray {
     strides: number[];
     data!: TypedArray;
 
-    constructor(data: TypedArray, shape?: number | number[], dtype?: DtypeString, stride?: number[])
-    constructor(data: Buffer | ArrayBuffer | null, shape: number | number[], dtype: DtypeString, stride?: number[])
-    constructor(data: Buffer | ArrayBuffer | TypedArray | null, shape?: number | number[], dtype?: DtypeString, stride?: number[]) {
+    constructor(data: TypedArray, shape?: number | number[], dtype?: DtypeString, strides?: number[])
+    constructor(data: Buffer | ArrayBuffer | null, shape: number | number[], dtype: DtypeString, strides?: number[])
+    constructor(data: Buffer | ArrayBuffer | TypedArray | null, shape?: number | number[], dtype?: DtypeString, strides?: number[]) {
         const dataIsTypedArray = data !== null && !!(data as TypedArray).BYTES_PER_ELEMENT;
 
         if (shape === undefined) {
@@ -23,6 +23,7 @@ export class RawArray {
             }
             shape = [(data as TypedArray).length];
         }
+        shape = normalizeShape(shape);
 
         if (dtype === undefined) {
             if (!dataIsTypedArray) {
@@ -31,13 +32,12 @@ export class RawArray {
             dtype = getTypedArrayDtypeString(data as TypedArray);
         }
 
-        shape = normalizeShape(shape);
-        this.shape = shape;
-        this.dtype = dtype;
-
         if (strides === undefined) {
             strides = getStrides(shape);
         }
+
+        this.shape = shape;
+        this.dtype = dtype;
         this.strides = strides;
 
         if (dataIsTypedArray && shape.length !== 1) {
@@ -67,10 +67,9 @@ export class RawArray {
         }
     }
 
-    public set(selection: ArraySelection = null, value: ArrayBuffer | number) {
+    public set(selection: ArraySelection = null, value: TypedArray | number) {
         if (selection === null) {
             selection = [slice(null)];
-            console.log('yo');
         }
 
         if (typeof value === "number") {
@@ -78,14 +77,11 @@ export class RawArray {
                 // Zero dimension array..
                 this.data[0] = value;
             } else {
-                // setNestedArrayToScalar(this.data, value, this.shape, selection);
-                console.log(selection, "number");
+                this.data.fill(value);
             }
         } else {
-            // setRawArray(this.data, value, this.shape, selection);
-            console.log(selection);
+            setRawArray(this.data, this.strides, value, this.shape, this.strides, selection);
         }
-
     }
 }
 

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -72,11 +72,10 @@ export class RawArray {
         }
     }
 
-    public set(selection: ArraySelection = null, value: RawArray | number, sourceSelection?: ArraySelection) {
+    public set(selection: ArraySelection = null, value: RawArray | number, valueSelection?: ArraySelection) {
         if (selection === null) {
             selection = [slice(null)];
         }
-
         if (typeof value === "number") {
             if (this.shape.length === 0) {
                 // Zero dimension array..
@@ -84,10 +83,11 @@ export class RawArray {
             } else {
                 setRawArrayToScalar(this.data, this.strides, this.shape, selection, value);
             }
-        } else if (sourceSelection) {
+        } if (value instanceof RawArray && valueSelection) {
             // Copy directly from decoded chunk to destination array
-            setRawArrayDirect(this.data, this.strides, this.shape, selection, value.data, value.strides, value.shape, sourceSelection);
+            setRawArrayDirect(this.data, this.strides, this.shape, selection, value.data, value.strides, value.shape, valueSelection);
         }
+
     }
 }
 

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -4,7 +4,7 @@ import { slice } from '../core/slice';
 import { ValueError } from '../errors';
 import { normalizeShape, IS_NODE, getStrides } from '../util';
 import { TypedArray, DTYPE_TYPEDARRAY_MAPPING, getTypedArrayDtypeString, TypedArrayConstructor } from '../nestedArray/types';
-import { setRawArray } from './ops';
+import { setRawArrayDirect } from './ops';
 
 export class RawArray {
     dtype: DtypeString;
@@ -72,7 +72,7 @@ export class RawArray {
         }
     }
 
-    public set(selection: ArraySelection = null, sourceSelection: ArraySelection, value: RawArray | number) {
+    public set(selection: ArraySelection = null, value: RawArray | number, sourceSelection?: ArraySelection) {
         if (selection === null) {
             selection = [slice(null)];
         }
@@ -84,8 +84,9 @@ export class RawArray {
             } else {
                 this.data.fill(value);
             }
-        } else {
-            setRawArray(this.data, this.strides, this.shape, selection, value.data, value.strides, value.shape, sourceSelection);
+        } else if (sourceSelection) {
+            // Copy directly from decoded chunk to destination array
+            setRawArrayDirect(this.data, this.strides, this.shape, selection, value.data, value.strides, value.shape, sourceSelection);
         }
     }
 }

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -1,0 +1,116 @@
+import { ArraySelection, SliceIndices } from '../core/types';
+import { ValueError } from '../errors';
+import { normalizeArraySelection, selectionToSliceIndices } from '../core/indexing';
+import { TypedArray, TypedArrayConstructor, NestedArrayData, NDNestedArrayData } from '../nestedArray/types';
+
+// TODO
+// export function setRawArrayToScalar<T extends TypedArray>(dstArr: NestedArrayData, value: number, destShape: number[], selection: number | ArraySelection) {
+//     // This translates "...", ":", null, etc into a list of slices.
+//     const normalizedSelection = normalizeArraySelection(selection, destShape, true);
+
+//     // Above we force the results to be SliceIndicesIndices only, without integer selections making this cast is safe.
+//     const [sliceIndices, _outShape] = selectionToSliceIndices(normalizedSelection, destShape) as [SliceIndices[], number[]];
+//     _setNestedArrayToScalar(dstArr, value, destShape, sliceIndices);
+// }
+
+export function setRawArray<T extends TypedArray>(dstArr: TypedArray, sourceArr: TypedArray, destShape: number[], selection: number | ArraySelection) {
+    // This translates "...", ":", null, etc into a list of slices.
+    const normalizedSelection = normalizeArraySelection(selection, destShape, false);
+    const [sliceIndices, outShape] = selectionToSliceIndices(normalizedSelection, destShape);
+
+    _setRawArray(dstArr, sourceArr, destShape, sliceIndices);
+}
+
+
+function _setRawArray<T extends TypedArray>(dstArr: NestedArrayData, sourceArr: NestedArrayData | number, shape: number[], selection: (SliceIndices | number)[]) {
+
+    const currentSlice = selection[0];
+
+    if (typeof sourceArr === "number") {
+        _setNestedArrayToScalar(dstArr, sourceArr, shape, selection.map(x => typeof x === "number" ? [x, x + 1, 1, 1] : x));
+        return;
+    }
+
+    // This dimension is squeezed.
+    if (typeof currentSlice === "number") {
+        _setNestedArray((dstArr as NDNestedArrayData)[currentSlice], sourceArr, shape.slice(1), selection.slice(1));
+        return;
+    }
+
+    const [from, _to, step, outputSize] = currentSlice;
+
+    if (shape.length === 1) {
+        if (step === 1) {
+            (dstArr as TypedArray).set(sourceArr as TypedArray, from);
+            return;
+        }
+
+        for (let i = 0; i < outputSize; i++) {
+            dstArr[from + i * step] = (sourceArr)[i];
+        }
+        return;
+    }
+
+    for (let i = 0; i < outputSize; i++) {
+        _setNestedArray((dstArr as NDNestedArrayData)[from + i * step], (sourceArr as NDNestedArrayData)[i], shape.slice(1), selection.slice(1));
+    }
+}
+
+// function _setNestedArrayToScalar<T extends TypedArray>(dstArr: NestedArrayData, value: number, shape: number[], selection: SliceIndices[]) {
+//     const currentSlice = selection[0];
+
+//     const [from, to, step, outputSize] = currentSlice;
+
+//     if (shape.length === 1) {
+//         if (step === 1) {
+//             (dstArr as TypedArray).fill(value, from, to);
+//             return;
+//         }
+
+//         for (let i = 0; i < outputSize; i++) {
+//             dstArr[from + i * step] = value;
+//         }
+//         return;
+//     }
+
+//     for (let i = 0; i < outputSize; i++) {
+//         _setNestedArrayToScalar((dstArr as NDNestedArrayData)[from + i * step], value, shape.slice(1), selection.slice(1));
+//     }
+// }
+
+// export function flattenNestedArray(arr: NestedArrayData, shape: number[], constr?: TypedArrayConstructor<TypedArray>): TypedArray {
+//     if (constr === undefined) {
+//         constr = getNestedArrayConstructor(arr);
+//     }
+//     const size = shape.reduce((x, y) => x * y, 1);
+//     const outArr = new constr(size);
+
+//     _flattenNestedArray(arr, shape, outArr, 0);
+
+//     return outArr;
+// }
+
+// function _flattenNestedArray(arr: NestedArrayData, shape: number[], outArr: TypedArray, offset: number) {
+//     if (shape.length === 1) {
+//         // This is only ever reached if called with rank 1 shape, never reached through recursion.
+//         // We just slice set the array directly from one level above to save some function calls.
+//         outArr.set((arr as TypedArray), offset);
+//         return;
+//     }
+
+//     if (shape.length === 2) {
+//         for (let i = 0; i < shape[0]; i++) {
+//             outArr.set((arr as TypedArray[])[i], offset + shape[1] * i);
+//         }
+//         return arr;
+//     }
+
+//     const nextShape = shape.slice(1);
+//     // Small optimization possible here: this can be precomputed for different levels of depth and passed on.
+//     const mult = nextShape.reduce((x, y) => x * y, 1);
+
+//     for (let i = 0; i < shape[0]; i++) {
+//         _flattenNestedArray((arr as NDNestedArrayData)[i], nextShape, outArr, offset + mult * i);
+//     }
+//     return arr;
+// }

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -77,16 +77,16 @@ function _setRawArrayDirect(dstArr: TypedArray, dstStrides: number[], dstOffset:
         return;
     }
 
-    for (let j = 0; j < outputSize; j++) {
+    for (let i = 0; i < outputSize; i++) {
         // Apply strides as above, using both destination and source-specific strides.
         _setRawArrayDirect(
             dstArr,
             nextDstStrides,
-            dstOffset + currentDstStride * (from + (j * step)),
+            dstOffset + currentDstStride * (from + (i * step)),
             nextDstSliceIndicies,
             sourceArr,
             nextSourceStrides,
-            sourceOffset + currentSourceStride * (sfrom + (j * sstep)),
+            sourceOffset + currentSourceStride * (sfrom + (i * sstep)),
             nextSourceSliceIndicies,
         );
     }
@@ -100,12 +100,18 @@ function _setRawArrayToScalar(value: number, dstArr: TypedArray, dstStrides: num
 
     if (dstStrides.length === 1) {
         for (let i = 0; i < outputSize; i++) {
-            dstArr[dstOffset + step * (from + i)] = value;
+            dstArr[dstOffset + currentDstStride * (from + (step * i))] = value;
         }
         return;
     }
 
-    for (let j = 0; j < outputSize; j++) {
-        _setRawArrayToScalar(value, dstArr, nextDstStrides, nextDstSliceIndicies, dstOffset + currentDstStride * (from + j));
+    for (let i = 0; i < outputSize; i++) {
+        _setRawArrayToScalar(
+            value,
+            dstArr,
+            nextDstStrides,
+            nextDstSliceIndicies,
+            dstOffset + currentDstStride * (from + (step * i))
+        );
     }
 }

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -34,7 +34,7 @@ function _setRawArray(dstArr: TypedArray, dstStrides: number[], dstOffset: numbe
 
     if (shape.length === 1) {
         for (let i = 0; i < outputSize; i++) {
-            dstArr[from + dstOffset + i] = sourceArr[sfrom + sourceOffset + i];
+            dstArr[dstOffset + from + i] = sourceArr[sourceOffset + sfrom + i];
         }
         return;
     }
@@ -43,10 +43,10 @@ function _setRawArray(dstArr: TypedArray, dstStrides: number[], dstOffset: numbe
         _setRawArray(
             dstArr,
             dstStrides.slice(1),
-            dstOffset + from * outputSize + dstStrides[0] * j,
+            dstOffset + dstStrides[0] * (from + j),
             sourceArr,
             sourceStrides.slice(1),
-            sourceOffset + sourceStrides[0] * j,
+            sourceOffset + sourceStrides[0] * (sfrom + j),
             shape.slice(1),
             selection.slice(1),
             sourceSelection.slice(1),

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -1,7 +1,7 @@
 import { ArraySelection, SliceIndices } from '../core/types';
 import { ValueError } from '../errors';
 import { normalizeArraySelection, selectionToSliceIndices } from '../core/indexing';
-import { TypedArray, TypedArrayConstructor, NestedArrayData, NDNestedArrayData } from '../nestedArray/types';
+import { TypedArray, TypedArrayConstructor } from '../nestedArray/types';
 
 // TODO
 // export function setRawArrayToScalar<T extends TypedArray>(dstArr: NestedArrayData, value: number, destShape: number[], selection: number | ArraySelection) {
@@ -17,44 +17,44 @@ export function setRawArray<T extends TypedArray>(dstArr: TypedArray, sourceArr:
     // This translates "...", ":", null, etc into a list of slices.
     const normalizedSelection = normalizeArraySelection(selection, destShape, false);
     const [sliceIndices, outShape] = selectionToSliceIndices(normalizedSelection, destShape);
-
-    _setRawArray(dstArr, sourceArr, destShape, sliceIndices);
+    console.log(sliceIndices, outShape);
+    // _setRawArray(dstArr, sourceArr, destShape, sliceIndices);
 }
 
 
-function _setRawArray<T extends TypedArray>(dstArr: NestedArrayData, sourceArr: NestedArrayData | number, shape: number[], selection: (SliceIndices | number)[]) {
+// function _setRawArray<T extends TypedArray>(dstArr: NestedArrayData, sourceArr: NestedArrayData | number, shape: number[], selection: (SliceIndices | number)[]) {
 
-    const currentSlice = selection[0];
+//     const currentSlice = selection[0];
 
-    if (typeof sourceArr === "number") {
-        _setNestedArrayToScalar(dstArr, sourceArr, shape, selection.map(x => typeof x === "number" ? [x, x + 1, 1, 1] : x));
-        return;
-    }
+//     if (typeof sourceArr === "number") {
+//         _setNestedArrayToScalar(dstArr, sourceArr, shape, selection.map(x => typeof x === "number" ? [x, x + 1, 1, 1] : x));
+//         return;
+//     }
 
-    // This dimension is squeezed.
-    if (typeof currentSlice === "number") {
-        _setNestedArray((dstArr as NDNestedArrayData)[currentSlice], sourceArr, shape.slice(1), selection.slice(1));
-        return;
-    }
+//     // This dimension is squeezed.
+//     if (typeof currentSlice === "number") {
+//         _setNestedArray((dstArr as NDNestedArrayData)[currentSlice], sourceArr, shape.slice(1), selection.slice(1));
+//         return;
+//     }
 
-    const [from, _to, step, outputSize] = currentSlice;
+//     const [from, _to, step, outputSize] = currentSlice;
 
-    if (shape.length === 1) {
-        if (step === 1) {
-            (dstArr as TypedArray).set(sourceArr as TypedArray, from);
-            return;
-        }
+//     if (shape.length === 1) {
+//         if (step === 1) {
+//             (dstArr as TypedArray).set(sourceArr as TypedArray, from);
+//             return;
+//         }
 
-        for (let i = 0; i < outputSize; i++) {
-            dstArr[from + i * step] = (sourceArr)[i];
-        }
-        return;
-    }
+//         for (let i = 0; i < outputSize; i++) {
+//             dstArr[from + i * step] = (sourceArr)[i];
+//         }
+//         return;
+//     }
 
-    for (let i = 0; i < outputSize; i++) {
-        _setNestedArray((dstArr as NDNestedArrayData)[from + i * step], (sourceArr as NDNestedArrayData)[i], shape.slice(1), selection.slice(1));
-    }
-}
+//     for (let i = 0; i < outputSize; i++) {
+//         _setNestedArray((dstArr as NDNestedArrayData)[from + i * step], (sourceArr as NDNestedArrayData)[i], shape.slice(1), selection.slice(1));
+//     }
+// }
 
 // function _setNestedArrayToScalar<T extends TypedArray>(dstArr: NestedArrayData, value: number, shape: number[], selection: SliceIndices[]) {
 //     const currentSlice = selection[0];

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -71,6 +71,9 @@ function _setRawArrayDirect(dstArr: TypedArray, dstStrides: number[], dstOffset:
     const [sfrom, _sto, sstep, _soutputSize] = currentSourceSlice; // Will always be subset of dst, so don't need output size just start
 
     if (dstStrides.length === 1 && sourceStrides.length === 1) {
+        // TODO: probably should use TypedArray.set(TypedArray, offset) for better performance
+        // if step === sstep currestDstStride === currentSourceStride === 1
+
         for (let i = 0; i < outputSize; i++) {
             dstArr[dstOffset + currentDstStride * (from + (step * i))] = sourceArr[sourceOffset + currentSourceStride * (sfrom + (sstep * i))];
         }

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -67,12 +67,12 @@ function _setRawArrayDirect(dstArr: TypedArray, dstStrides: number[], dstOffset:
         return;
     }
 
-    const [from, _to, _step, outputSize] = currentDstSlice; // just need start and size
-    const [sfrom] = currentSourceSlice; // Will always be subset of dst, so don't need output size just start
+    const [from, _to, step, outputSize] = currentDstSlice; // just need start and size
+    const [sfrom, _sto, sstep, _soutputSize] = currentSourceSlice; // Will always be subset of dst, so don't need output size just start
 
     if (dstStrides.length === 1 && sourceStrides.length === 1) {
         for (let i = 0; i < outputSize; i++) {
-            dstArr[dstOffset + currentDstStride * (from + i)] = sourceArr[sourceOffset + currentSourceStride * (sfrom + i)];
+            dstArr[dstOffset + step * (from + i)] = sourceArr[sourceOffset + sstep * (sfrom + i)];
         }
         return;
     }
@@ -96,11 +96,11 @@ function _setRawArrayToScalar(value: number, dstArr: TypedArray, dstStrides: num
     const [currentDstSlice, ...nextDstSliceIndicies] = dstSliceIndices;
     const [currentDstStride, ...nextDstStrides] = dstStrides;
 
-    const [from, _to, _step, outputSize] = currentDstSlice;
+    const [from, _to, step, outputSize] = currentDstSlice;
 
     if (dstStrides.length === 1) {
         for (let i = 0; i < outputSize; i++) {
-            dstArr[dstOffset + currentDstStride * (from + i)] = value;
+            dstArr[dstOffset + step * (from + i)] = value;
         }
         return;
     }

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -13,12 +13,12 @@ export function setRawArrayToScalar(dstArr: TypedArray, dstStrides: number[], ds
 export function setRawArrayDirect(dstArr: TypedArray, dstStrides: number[], dstShape: number[], dstSelection: number | ArraySelection, sourceArr: TypedArray, sourceStrides: number[], sourceShape: number[], sourceSelection: number | ArraySelection) {
     // This translates "...", ":", null, etc into a list of slices.
     const normalizedDstSelection = normalizeArraySelection(dstSelection, dstShape, true);
+    // Above we force the results to be dstSliceIndices only, without integer selections making this cast is safe.
     const [dstSliceIndices] = selectionToSliceIndices(normalizedDstSelection, dstShape);
 
     const normalizedSourceSelection = normalizeArraySelection(sourceSelection, sourceShape, false);
     const [sourceSliceIndicies] = selectionToSliceIndices(normalizedSourceSelection, sourceShape);
 
-    // Above we force the results to be dstSliceIndices only, without integer selections making this cast is safe.
     _setRawArrayDirect(dstArr, dstStrides, 0, dstSliceIndices as SliceIndices[], sourceArr, sourceStrides, 0, sourceSliceIndicies);
 }
 
@@ -72,7 +72,7 @@ function _setRawArrayDirect(dstArr: TypedArray, dstStrides: number[], dstOffset:
 
     if (dstStrides.length === 1 && sourceStrides.length === 1) {
         for (let i = 0; i < outputSize; i++) {
-            dstArr[dstOffset + step * (from + i)] = sourceArr[sourceOffset + sstep * (sfrom + i)];
+            dstArr[dstOffset + currentDstStride * (from + (step * i))] = sourceArr[sourceOffset + currentSourceStride * (sfrom + (sstep * i))];
         }
         return;
     }
@@ -82,11 +82,11 @@ function _setRawArrayDirect(dstArr: TypedArray, dstStrides: number[], dstOffset:
         _setRawArrayDirect(
             dstArr,
             nextDstStrides,
-            dstOffset + currentDstStride * (from + j),
+            dstOffset + currentDstStride * (from + (j * step)),
             nextDstSliceIndicies,
             sourceArr,
             nextSourceStrides,
-            sourceOffset + currentSourceStride * (sfrom + j),
+            sourceOffset + currentSourceStride * (sfrom + (j * sstep)),
             nextSourceSliceIndicies,
         );
     }

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -116,7 +116,7 @@ function _setRawArray(dstArr: TypedArray, dstStrides: number[], dstSliceIndices:
 function _setRawArrayFromChunkItem(dstArr: TypedArray, dstStrides: number[], dstSliceIndices: SliceIndices[], sourceArr: TypedArray, sourceStrides: number[], sourceSliceIndices: (SliceIndices | number)[]) {
     if (sourceSliceIndices.length === 0) {
         // Case when last source dimension is squeezed
-        dstArr.set(sourceArr);
+        dstArr.set(sourceArr.subarray(0, dstArr.length));
         return;
     }
 

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -24,8 +24,24 @@ function _setRawArray(dstArr: TypedArray, dstStrides: number[], dstOffset: numbe
         return;
     }
 
-    if (typeof currentDstSlice === "number" || typeof currentSourceSlice === "number") {
+    if (typeof currentDstSlice === "number") {
         console.warn("setting single index not implemented.");
+        return;
+    }
+
+    // This dimension is squeezed
+    if (typeof currentSourceSlice === "number") {
+        _setRawArray(
+            dstArr,
+            dstStrides,
+            dstOffset,
+            sourceArr,
+            sourceStrides.slice(1),
+            sourceOffset + sourceStrides[0] * currentSourceSlice,
+            shape,
+            selection,
+            sourceSelection.slice(1),
+        );
         return;
     }
 

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -54,7 +54,7 @@ function _setRawArrayDirect(dstArr: TypedArray, dstStrides: number[], dstOffset:
         return;
     }
 
-    const [from, , outputSize] = currentDstSlice;
+    const [from, , , outputSize] = currentDstSlice;
     const [sfrom] = currentSourceSlice; // Will always be subset of dst, so don't need output size
 
     if (dstStrides.length === 1 && sourceStrides.length === 1) {

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -1,28 +1,16 @@
 import { ArraySelection, SliceIndices } from '../core/types';
 import { ValueError } from '../errors';
 import { normalizeArraySelection, selectionToSliceIndices } from '../core/indexing';
-import { TypedArray, TypedArrayConstructor } from '../nestedArray/types';
+import { TypedArray } from '../nestedArray/types';
 
-// TODO
-// export function setRawArrayToScalar<T extends TypedArray>(dstArr: NestedArrayData, value: number, destShape: number[], selection: number | ArraySelection) {
-//     // This translates "...", ":", null, etc into a list of slices.
-//     const normalizedSelection = normalizeArraySelection(selection, destShape, true);
-
-//     // Above we force the results to be SliceIndicesIndices only, without integer selections making this cast is safe.
-//     const [sliceIndices, _outShape] = selectionToSliceIndices(normalizedSelection, destShape) as [SliceIndices[], number[]];
-//     _setNestedArrayToScalar(dstArr, value, destShape, sliceIndices);
-// }
-
-export function setRawArray(dstArr: TypedArray, strides: number[] | number, sourceArr: TypedArray, destShape: number[], destStrides: number[], selection: number | ArraySelection) {
+export function setRawArray(dstArr: TypedArray, dstStrides: number[], sourceArr: TypedArray, sourceStrides: number[], destShape: number[], selection: number | ArraySelection) {
     // This translates "...", ":", null, etc into a list of slices.
     const normalizedSelection = normalizeArraySelection(selection, destShape, false);
     const [sliceIndices, outShape] = selectionToSliceIndices(normalizedSelection, destShape);
-    console.log(dstArr);
-    console.log(sourceArr);
-    _setRawArray(dstArr, strides, sourceArr, destShape, sliceIndices);
+    _setRawArray(dstArr, dstStrides, 0, sourceArr, sourceStrides.slice(1), 0, destShape, sliceIndices);
 }
 
-function _setRawArray(dstArr: TypedArray, strides: number[] | number, sourceArr: TypedArray | number, shape: number[], selection: (SliceIndices | number)[]) {
+function _setRawArray(dstArr: TypedArray, dstStrides: number[], dstOffset: number, sourceArr: TypedArray | number, sourceStrides: number[], sourceOffset: number, shape: number[], selection: (SliceIndices | number)[]) {
     const currentSlice = selection[0];
 
     if (typeof sourceArr === "number") {
@@ -31,63 +19,30 @@ function _setRawArray(dstArr: TypedArray, strides: number[] | number, sourceArr:
     }
 
     if (typeof currentSlice === "number") {
-        _setRawArray(dstArr, strides, sourceArr, shape.slice(1), selection.slice(1));
+        console.warn("setting single index not implemented.");
         return;
     }
 
-    if (typeof strides === "number") console.log('not implemented yet');
-
     const [from, _to, step, outputSize] = currentSlice;
-    console.log(currentSlice, outputSize);
 
     if (shape.length === 1) {
-        if (step === 1) {
-            dstArr.set(sourceArr, from);
-            return;
-        }
-
-        for (let i = 0; i < outputSize; i++) {
-            dstArr[from + i * step] = (sourceArr)[i];
+        for (let j = 0; j < outputSize; j++) {
+            console.log(sourceArr[sourceOffset + j]);
+            dstArr[from + dstOffset + j] = sourceArr[sourceOffset + j];
         }
         return;
     }
 
     for (let i = 0; i < outputSize; i++) {
-        _setRawArray(dstArr, strides.slice(1), sourceArr, shape.slice(1), selection.slice(1));
+        _setRawArray(
+            dstArr,
+            dstStrides.slice(1),
+            dstOffset + i * dstStrides[0],
+            sourceArr,
+            sourceStrides.slice(1),
+            sourceOffset + i * sourceStrides[0],
+            shape.slice(1),
+            selection.slice(1)
+        );
     }
 }
-
-
-// function _setRawArray<T extends TypedArray>(dstArr: NestedArrayData, sourceArr: NestedArrayData | number, shape: number[], selection: (SliceIndices | number)[]) {
-
-//     const currentSlice = selection[0];
-
-//     if (typeof sourceArr === "number") {
-//         _setNestedArrayToScalar(dstArr, sourceArr, shape, selection.map(x => typeof x === "number" ? [x, x + 1, 1, 1] : x));
-//         return;
-//     }
-
-//     // This dimension is squeezed.
-//     if (typeof currentSlice === "number") {
-//         _setNestedArray((dstArr as NDNestedArrayData)[currentSlice], sourceArr, shape.slice(1), selection.slice(1));
-//         return;
-//     }
-
-//     const [from, _to, step, outputSize] = currentSlice;
-
-//     if (shape.length === 1) {
-//         if (step === 1) {
-//             (dstArr as TypedArray).set(sourceArr as TypedArray, from);
-//             return;
-//         }
-
-//         for (let i = 0; i < outputSize; i++) {
-//             dstArr[from + i * step] = (sourceArr)[i];
-//         }
-//         return;
-//     }
-
-//     for (let i = 0; i < outputSize; i++) {
-//         _setNestedArray((dstArr as NDNestedArrayData)[from + i * step], (sourceArr as NDNestedArrayData)[i], shape.slice(1), selection.slice(1));
-//     }
-// }

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -71,8 +71,11 @@ function _setRawArrayDirect(dstArr: TypedArray, dstStrides: number[], dstOffset:
     const [sfrom, _sto, sstep, _soutputSize] = currentSourceSlice; // Will always be subset of dst, so don't need output size just start
 
     if (dstStrides.length === 1 && sourceStrides.length === 1) {
-        // TODO: probably should use TypedArray.set(TypedArray, offset) for better performance
-        // if step === sstep currestDstStride === currentSourceStride === 1
+        if (step === 1 && currentDstStride === 1 && sstep === 1 && currentSourceStride === 1) {
+            const subView = sourceArr.subarray(sourceOffset + sfrom, sourceOffset + sfrom + outputSize);
+            dstArr.set(subView, dstOffset + from);
+            return;
+        }
 
         for (let i = 0; i < outputSize; i++) {
             dstArr[dstOffset + currentDstStride * (from + (step * i))] = sourceArr[sourceOffset + currentSourceStride * (sfrom + (sstep * i))];

--- a/src/rawArray/ops.ts
+++ b/src/rawArray/ops.ts
@@ -3,46 +3,53 @@ import { ValueError } from '../errors';
 import { normalizeArraySelection, selectionToSliceIndices } from '../core/indexing';
 import { TypedArray } from '../nestedArray/types';
 
-export function setRawArray(dstArr: TypedArray, dstStrides: number[], sourceArr: TypedArray, sourceStrides: number[], destShape: number[], selection: number | ArraySelection) {
+export function setRawArray(dstArr: TypedArray, dstStrides: number[], dstShape: number[], dstSelection: number | ArraySelection, sourceArr: TypedArray, sourceStrides: number[], sourceShape: number[], sourceSelection: number | ArraySelection) {
     // This translates "...", ":", null, etc into a list of slices.
-    const normalizedSelection = normalizeArraySelection(selection, destShape, false);
-    const [sliceIndices, outShape] = selectionToSliceIndices(normalizedSelection, destShape);
-    _setRawArray(dstArr, dstStrides, 0, sourceArr, sourceStrides.slice(1), 0, destShape, sliceIndices);
+    const normalizedDstSelection = normalizeArraySelection(dstSelection, dstShape, false);
+    const [dstSliceIndices, outShape] = selectionToSliceIndices(normalizedDstSelection, dstShape);
+
+    const normalizedSourceSelection = normalizeArraySelection(sourceSelection, sourceShape, false);
+    const [sourceSliceIndicies, sShape] = selectionToSliceIndices(normalizedSourceSelection, sourceShape);
+
+    _setRawArray(dstArr, dstStrides, 0, sourceArr, sourceStrides, 0, dstShape, dstSliceIndices, sourceSliceIndicies);
 }
 
-function _setRawArray(dstArr: TypedArray, dstStrides: number[], dstOffset: number, sourceArr: TypedArray | number, sourceStrides: number[], sourceOffset: number, shape: number[], selection: (SliceIndices | number)[]) {
-    const currentSlice = selection[0];
+function _setRawArray(dstArr: TypedArray, dstStrides: number[], dstOffset: number, sourceArr: TypedArray | number, sourceStrides: number[], sourceOffset: number, shape: number[], selection: (SliceIndices | number)[], sourceSelection: (SliceIndices | number)[]) {
+    const currentDstSlice = selection[0];
+    const currentSourceSlice = sourceSelection[0];
+
 
     if (typeof sourceArr === "number") {
         console.warn("setting selection to scalar not yet implemented");
         return;
     }
 
-    if (typeof currentSlice === "number") {
+    if (typeof currentDstSlice === "number" || typeof currentSourceSlice === "number") {
         console.warn("setting single index not implemented.");
         return;
     }
 
-    const [from, _to, step, outputSize] = currentSlice;
+    const [from, _to, step, outputSize] = currentDstSlice;
+    const [sfrom, _sto, sstep, soutputSize] = currentSourceSlice;
 
     if (shape.length === 1) {
-        for (let j = 0; j < outputSize; j++) {
-            console.log(sourceArr[sourceOffset + j]);
-            dstArr[from + dstOffset + j] = sourceArr[sourceOffset + j];
+        for (let i = 0; i < outputSize; i++) {
+            dstArr[from + dstOffset + i] = sourceArr[sfrom + sourceOffset + i];
         }
         return;
     }
 
-    for (let i = 0; i < outputSize; i++) {
+    for (let j = 0; j < outputSize; j++) {
         _setRawArray(
             dstArr,
             dstStrides.slice(1),
-            dstOffset + i * dstStrides[0],
+            dstOffset + from * outputSize + dstStrides[0] * j,
             sourceArr,
             sourceStrides.slice(1),
-            sourceOffset + i * sourceStrides[0],
+            sourceOffset + sourceStrides[0] * j,
             shape.slice(1),
-            selection.slice(1)
+            selection.slice(1),
+            sourceSelection.slice(1),
         );
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -128,8 +128,8 @@ export function normalizeFillValue(fillValue: FillType): FillType {
 /**
  * Determine whether `item` specifies a complete slice of array with the
  *  given `shape`. Used to optimize __setitem__ operations on chunks
- * @param item 
- * @param shape 
+ * @param item
+ * @param shape
  */
 export function isTotalSlice(item: DimensionSelection | DimensionSelection[], shape: number[]): boolean {
     if (item === null) {
@@ -180,4 +180,22 @@ export function arrayEquals1D(a: ArrayLike<any>, b: ArrayLike<any>) {
         }
     }
     return true;
+}
+
+/*
+ * Determines "C" order strides for a given shape array.
+ * Strides provide integer steps in each dimention to traverse an ndarray.
+ *
+ * NOTE: These strides here are distinct from numpy.ndarray.strides, which describe actual byte steps.
+ */
+export function getStrides(shape: number[]): number[] {
+    // adapted from https://github.com/scijs/ndarray/blob/master/ndarray.js#L326-L330
+    const ndim = shape.length;
+    const strides = Array(ndim);
+    let step = 1; // strides assumed to be contiguous, so init step is 1
+    for (let i = ndim - 1; i >= 0; i--) {
+        strides[i] = step;
+        step *= shape[i];
+    }
+    return strides;
 }

--- a/test/core/indexing.test.ts
+++ b/test/core/indexing.test.ts
@@ -112,7 +112,6 @@ describe("GetBasicSelection1DSimple", () => {
     it("can select slices and single values, uses fill value", async () => {
         await setup("array_name_0");
         const z = await ZarrArray.create(store, "array_name_0");
-        expect((await z.getBasicSelection([slice(1, 3)])).data).toEqual(Int32Array.from([1, 2]));
         expect(await z.getBasicSelection(0)).toEqual(0);
         expect(await z.getBasicSelection(3)).toEqual(3);
 
@@ -176,6 +175,12 @@ describe("GetBasicSelections1D", () => {
         await z.set(null, nestedArr);
         await testGetBasicSelection(z, selection, nestedArr);
     });
+
+    test.each(basicSelections1D)(`%p`, async (selection) => {
+        const z = await create({ shape: nestedArr.shape, chunks: [100], dtype: nestedArr.dtype });
+        await z.set(null, nestedArr);
+        await testGetBasicSelectionRaw(z, selection, nestedArr);
+    });
 });
 
 describe("GetBasicSelections2D", () => {
@@ -200,7 +205,7 @@ describe("GetBasicSelections2D", () => {
         slice(-1, 0),  // empty result N
         slice(-2000, 0), // N
         slice(-2000, 2000),
-        // 2D slices
+        // // 2D slices
         [slice(null), slice(1, 5)],
         [slice(250, 350), slice(null)],
         [slice(250, 350), slice(1, 5)],
@@ -228,6 +233,12 @@ describe("GetBasicSelections2D", () => {
         await z.set(null, nestedArr);
         await testGetBasicSelection(z, selection, nestedArr);
     });
+
+    test.each(basicSelections2D)(`%p`, async (selection) => {
+        const z = await create({ shape: nestedArr.shape, chunks: [400, 3], dtype: nestedArr.dtype });
+        await z.set(null, nestedArr);
+        await testGetBasicSelectionRaw(z, selection, nestedArr);
+    });
 });
 
 async function testGetBasicSelection(z: ZarrArray, selection: any, data: NestedArray<TypedArray>) {
@@ -239,5 +250,16 @@ async function testGetBasicSelection(z: ZarrArray, selection: any, data: NestedA
     else {
         expect((selectedFromZarrArray as NestedArray<any>).flatten())
             .toEqual((selectedFromSource as NestedArray<any>).flatten());
+    }
+}
+
+async function testGetBasicSelectionRaw(z: ZarrArray, selection: any, data: NestedArray<TypedArray>) {
+    const selectedFromZarrArray = await z.getBasicSelection(selection, true); // asRaw === true
+    const selectedFromSource = data.get(selection);
+    if (typeof selectedFromZarrArray === "number") {
+        expect(selectedFromZarrArray).toEqual(selectedFromSource);
+    }
+    else {
+        expect(selectedFromZarrArray.data).toEqual((selectedFromSource as NestedArray<any>).flatten());
     }
 }

--- a/test/core/indexing.test.ts
+++ b/test/core/indexing.test.ts
@@ -112,6 +112,7 @@ describe("GetBasicSelection1DSimple", () => {
     it("can select slices and single values, uses fill value", async () => {
         await setup("array_name_0");
         const z = await ZarrArray.create(store, "array_name_0");
+        expect((await z.getBasicSelection([slice(1, 3)]) as NestedArray<Int32Array>).data).toEqual(Int32Array.from([1, 2]));
         expect(await z.getBasicSelection(0)).toEqual(0);
         expect(await z.getBasicSelection(3)).toEqual(3);
 
@@ -205,7 +206,7 @@ describe("GetBasicSelections2D", () => {
         slice(-1, 0),  // empty result N
         slice(-2000, 0), // N
         slice(-2000, 2000),
-        // // 2D slices
+        // 2D slices
         [slice(null), slice(1, 5)],
         [slice(250, 350), slice(null)],
         [slice(250, 350), slice(1, 5)],

--- a/test/rawArray/index.test.ts
+++ b/test/rawArray/index.test.ts
@@ -1,0 +1,19 @@
+import { RawArray } from "../../src/rawArray";
+
+
+describe("RawArray interface", () => {
+
+    it("errors given invalid buffer size", () => {
+        expect(() => new RawArray(new ArrayBuffer(8), [2], "<i4")).not.toThrowError();
+        expect(() => new RawArray(new ArrayBuffer(7), [2], "<i4")).toThrowError();
+        expect(() => new RawArray(new ArrayBuffer(4), [2], "<i4")).toThrowError();
+        expect(() => new RawArray(new ArrayBuffer(16), [2], "<i4")).toThrowError();
+    });
+
+
+    it("errors when not passing required params", () => {
+        expect(() => new RawArray(new ArrayBuffer(8) as any, [2])).toThrowError();
+        expect(() => new RawArray(new ArrayBuffer(8) as any, undefined, "<i4")).toThrowError();
+    });
+
+});

--- a/test/rawArray/ops.setting.test.ts
+++ b/test/rawArray/ops.setting.test.ts
@@ -1,11 +1,217 @@
 import { TypedArrayConstructor, TypedArray } from "../../src/nestedArray/types";
 import { rangeTypedArray } from "../../src/nestedArray";
-import { setRawArrayDirect, setRawArrayToScalar } from "../../src/rawArray/ops";
+import { setRawArray, setRawArrayToScalar, setRawArrayFromChunkItem } from "../../src/rawArray/ops";
 import { Slice } from "../../src/core/types";
 import { slice } from "../../src/core/slice";
 import { RawArray } from "../../src/rawArray";
 
 describe("RawArray setting", () => {
+    interface TestCase {
+        name: string;
+        destShape: number[];
+        sourceShape: number[];
+        constr: TypedArrayConstructor<TypedArray>;
+        selection: (Slice | number)[];
+        expected: TypedArray;
+    }
+
+
+    const testCases: TestCase[] = [
+        {
+            name: "1d_3",
+            destShape: [3],
+            sourceShape: [3],
+            constr: Int32Array,
+            selection: [slice(null)],
+            expected: Int32Array.from([0, 1, 2]),
+        },
+        {
+            name: "1d_3",
+            destShape: [3],
+            sourceShape: [2],
+            constr: Int32Array,
+            selection: [slice(1, 3)],
+            expected: Int32Array.from([0, 0, 1]),
+        },
+        {
+            name: "1d_3_step_-1",
+            destShape: [3],
+            sourceShape: [2],
+            constr: Int32Array,
+            selection: [slice(2, 0, -1)],
+            expected: Int32Array.from([0, 1, 0]),
+        },
+        {
+            name: "1d_3_step_2",
+            destShape: [3],
+            sourceShape: [2],
+            constr: Int32Array,
+            selection: [slice(0, null, 2)],
+            expected: Int32Array.from([0, 1, 1]),
+        },
+        {
+            name: "1d_5_step_-2",
+            destShape: [5],
+            sourceShape: [3],
+            constr: Int32Array,
+            selection: [slice(null, null, -2)],
+            expected: Int32Array.from([2, 1, 1, 3, 0]),
+        },
+        {
+            name: "2d_2x3",
+            destShape: [2, 3],
+            sourceShape: [2, 3],
+            constr: Int32Array,
+            selection: [slice(null)],
+            expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
+        },
+        {
+            name: "2d_2x3_s",
+            destShape: [2, 3],
+            sourceShape: [3],
+            constr: Int32Array,
+            selection: [0],
+            expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
+        },
+        {
+            name: "2d_2x3_s",
+            destShape: [2, 3],
+            sourceShape: [2],
+            constr: Int32Array,
+            selection: [slice(null), 0],
+            expected: Int32Array.from([0, 1, 2, 1, 4, 5]),
+        },
+        {
+            name: "2d_2x3_int_index",
+            destShape: [2, 3],
+            sourceShape: [3],
+            constr: Int32Array,
+            selection: [1],
+            expected: Int32Array.from([0, 1, 2, 0, 1, 2]),
+        },
+        {
+            name: "2d_2x3_int_index_step_-1",
+            destShape: [2, 3],
+            sourceShape: [3],
+            constr: Int32Array,
+            selection: [1, slice(null, null, -1)],
+            expected: Int32Array.from([0, 1, 2, 2, 1, 0]),
+        },
+        {
+            name: "2d_2x3_empty",
+            destShape: [2, 3],
+            sourceShape: [0, 3],
+            constr: Int32Array,
+            selection: [slice(0, 0)],
+            expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
+        },
+        {
+            name: "5d_1x2x1x2x3_int_index_negative_slice",
+            destShape: [1, 2, 1, 2, 3],
+            sourceShape: [2, 3],
+            constr: Int32Array,
+            selection: [0, 1, 0, slice(null, null, -1), slice(null, null, -1)],
+            expected: Int32Array.from([0, 1, 2, 3, 4, 5, 5, 4, 3, 2, 1, 0])
+        },
+        {
+            name: "4d_1x2x2x4",
+            destShape: [1, 2, 2, 4],
+            sourceShape: [1, 2, 2, 4],
+            constr: Int32Array,
+            selection: [slice(null), slice(null), slice(null), slice(null)],
+            expected: Int32Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        },
+        {
+            name: "4d_1x2x2x4_step_-1",
+            destShape: [1, 2, 2, 4],
+            sourceShape: [1, 2, 2, 4],
+            constr: Int32Array,
+            selection: [slice(null), slice(null), slice(null), slice(null, null, -1)],
+            expected: Int32Array.from([3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12])
+        },
+        {
+            name: "4d_1x2x2x4_step_-1_partial",
+            destShape: [1, 2, 2, 4],
+            sourceShape: [1, 1, 2, 4],
+            constr: Int32Array,
+            selection: [slice(null), slice(null, 1), slice(null), slice(null, null, -1)],
+            expected: Int32Array.from([3, 2, 1, 0, 7, 6, 5, 4, 8, 9, 10, 11, 12, 13, 14, 15])
+        },
+    ];
+
+
+    test.each(testCases)(`%p`, (t: TestCase) => {
+        const sourceData = rangeTypedArray(t.sourceShape, t.constr);
+        const sourceRawArray = new RawArray(new t.constr(sourceData.buffer), t.sourceShape);
+
+        const destData = rangeTypedArray(t.destShape, t.constr);
+        const destRawArray = new RawArray(new t.constr(destData.buffer), t.destShape);
+
+        setRawArray(
+            destRawArray.data,
+            destRawArray.strides,
+            t.destShape,
+            t.selection,
+            sourceRawArray.data,
+            sourceRawArray.strides,
+            t.sourceShape,
+        );
+
+        expect(destRawArray.data).toEqual(t.expected);
+    });
+
+
+});
+
+describe("RawArray scalar setting", () => {
+    interface TestCase {
+        name: string;
+        destShape: number[];
+        value: number;
+        constr: TypedArrayConstructor<TypedArray>;
+        selection: (Slice | number)[];
+        expected: TypedArray;
+    }
+
+
+    const testCases: TestCase[] = [
+        {
+            name: "1d_3",
+            destShape: [3],
+            value: 2,
+            constr: Int32Array,
+            selection: [slice(null)],
+            expected: Int32Array.from([2, 2, 2]),
+        },
+        {
+            name: "4d_1x2x2x4",
+            destShape: [1, 2, 2, 4],
+            value: 3,
+            constr: Int32Array,
+            selection: [slice(null), slice(0, 1), slice(null), slice(null)],
+            expected: Int32Array.from([3, 3, 3, 3, 3, 3, 3, 3, 8, 9, 10, 11, 12, 13, 14, 15])
+        },
+        {
+            name: "4d_1x2x2x4_step_2",
+            destShape: [1, 2, 2, 4],
+            value: 3,
+            constr: Int32Array,
+            selection: [slice(null), slice(0, 1), slice(null), slice(null, null, 2)],
+            expected: Int32Array.from([3, 1, 3, 3, 3, 5, 3, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        },
+    ];
+
+
+    test.each(testCases)(`%p`, (t: TestCase) => {
+        const destData = rangeTypedArray(t.destShape, t.constr);
+        const destRawArray = new RawArray(new t.constr(destData.buffer), t.destShape);
+        setRawArrayToScalar(destRawArray.data, destRawArray.strides, t.destShape, t.selection, t.value);
+        expect(destRawArray.data).toEqual(t.expected);
+    });
+
+});
+
+describe("RawArray setting from chunkItem", () => {
     interface TestCase {
         name: string;
         destShape: number[];
@@ -100,7 +306,7 @@ describe("RawArray setting", () => {
         const destData = rangeTypedArray(t.destShape, t.constr);
         const destRawArray = new RawArray(new t.constr(destData.buffer), t.destShape);
 
-        setRawArrayDirect(
+        setRawArrayFromChunkItem(
             destRawArray.data,
             destRawArray.strides,
             t.destShape,
@@ -110,59 +316,9 @@ describe("RawArray setting", () => {
             t.sourceShape,
             t.sourceSelection
         );
-        if (t.name === "4d_1x2x2x4_step_2") {
-            console.warn('here');
-        }
+
         expect(destRawArray.data).toEqual(t.expected);
     });
 
-
-});
-
-describe("RawArray scalar setting", () => {
-    interface TestCase {
-        name: string;
-        destShape: number[];
-        value: number;
-        constr: TypedArrayConstructor<TypedArray>;
-        selection: (Slice | number)[];
-        expected: TypedArray;
-    }
-
-
-    const testCases: TestCase[] = [
-        {
-            name: "1d_3",
-            destShape: [3],
-            value: 2,
-            constr: Int32Array,
-            selection: [slice(null)],
-            expected: Int32Array.from([2, 2, 2]),
-        },
-        {
-            name: "4d_1x2x2x4",
-            destShape: [1, 2, 2, 4],
-            value: 3,
-            constr: Int32Array,
-            selection: [slice(null), slice(0, 1), slice(null), slice(null)],
-            expected: Int32Array.from([3, 3, 3, 3, 3, 3, 3, 3, 8, 9, 10, 11, 12, 13, 14, 15])
-        },
-        {
-            name: "4d_1x2x2x4_step_2",
-            destShape: [1, 2, 2, 4],
-            value: 3,
-            constr: Int32Array,
-            selection: [slice(null), slice(0, 1), slice(null), slice(null, null, 2)],
-            expected: Int32Array.from([3, 1, 3, 3, 3, 5, 3, 7, 8, 9, 10, 11, 12, 13, 14, 15])
-        },
-    ];
-
-
-    test.each(testCases)(`%p`, (t: TestCase) => {
-        const destData = rangeTypedArray(t.destShape, t.constr);
-        const destRawArray = new RawArray(new t.constr(destData.buffer), t.destShape);
-        setRawArrayToScalar(destRawArray.data, destRawArray.strides, t.destShape, t.selection, t.value);
-        expect(destRawArray.data).toEqual(t.expected);
-    });
 
 });

--- a/test/rawArray/ops.setting.test.ts
+++ b/test/rawArray/ops.setting.test.ts
@@ -1,0 +1,216 @@
+import { TypedArrayConstructor, TypedArray } from "../../src/nestedArray/types";
+import { rangeTypedArray } from "../../src/nestedArray";
+import { setRawArrayDirect, setRawArrayToScalar } from "../../src/rawArray/ops";
+import { Slice } from "../../src/core/types";
+import { slice } from "../../src/core/slice";
+import { RawArray } from "../../src/rawArray";
+
+// describe("RawArray setting", () => {
+//     interface TestCase {
+//         name: string;
+//         destShape: number[];
+//         sourceShape: number[];
+//         constr: TypedArrayConstructor<TypedArray>;
+//         selection: (Slice | number)[];
+//         expected: TypedArray;
+//     }
+
+
+//     const testCases: TestCase[] = [
+//         {
+//             name: "1d_3",
+//             destShape: [3],
+//             sourceShape: [3],
+//             constr: Int32Array,
+//             selection: [slice(null)],
+//             expected: Int32Array.from([0, 1, 2]),
+//         },
+//         {
+//             name: "1d_3",
+//             destShape: [3],
+//             sourceShape: [2],
+//             constr: Int32Array,
+//             selection: [slice(1, 3)],
+//             expected: Int32Array.from([0, 0, 1]),
+//         },
+//         {
+//             name: "1d_3_step_-1",
+//             destShape: [3],
+//             sourceShape: [2],
+//             constr: Int32Array,
+//             selection: [slice(2, 0, -1)],
+//             expected: Int32Array.from([0, 1, 0]),
+//         },
+//         {
+//             name: "1d_3_step_2",
+//             destShape: [3],
+//             sourceShape: [2],
+//             constr: Int32Array,
+//             selection: [slice(0, null, 2)],
+//             expected: Int32Array.from([0, 1, 1]),
+//         },
+//         {
+//             name: "1d_5_step_-3",
+//             destShape: [5],
+//             sourceShape: [3],
+//             constr: Int32Array,
+//             selection: [slice(null, null, -2)],
+//             expected: Int32Array.from([2, 1, 1, 3, 0]),
+//         },
+//         {
+//             name: "2d_2x3",
+//             destShape: [2, 3],
+//             sourceShape: [2, 3],
+//             constr: Int32Array,
+//             selection: [slice(null)],
+//             expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
+//         },
+//         {
+//             name: "2d_2x3_s",
+//             destShape: [2, 3],
+//             sourceShape: [3],
+//             constr: Int32Array,
+//             selection: [0],
+//             expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
+//         },
+//         {
+//             name: "2d_2x3_s",
+//             destShape: [2, 3],
+//             sourceShape: [2],
+//             constr: Int32Array,
+//             selection: [slice(null), 0],
+//             expected: Int32Array.from([0, 1, 2, 1, 4, 5])
+//         },
+//         {
+//             name: "2d_2x3_int_index",
+//             destShape: [2, 3],
+//             sourceShape: [3],
+//             constr: Int32Array,
+//             selection: [1],
+//             expected: Int32Array.from([0, 1, 2, 0, 1, 2]),
+//         },
+//         {
+//             name: "2d_2x3_int_index_step_-1",
+//             destShape: [2, 3],
+//             sourceShape: [3],
+//             constr: Int32Array,
+//             selection: [1, slice(null, null, -1)],
+//             expected: Int32Array.from([0, 1, 2, 2, 1, 0]),
+//         },
+//         {
+//             name: "2d_2x3_empty",
+//             destShape: [2, 3],
+//             sourceShape: [0, 3],
+//             constr: Int32Array,
+//             selection: [slice(0, 0)],
+//             expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
+//         },
+//         {
+//             name: "5d_1x2x1x2x3_int_index_negative_slice",
+//             destShape: [1, 2, 1, 2, 3],
+//             sourceShape: [2, 3],
+//             constr: Int32Array,
+//             selection: [0, 1, 0, slice(null, null, -1), slice(null, null, -1)],
+//             expected: Int32Array.from([0, 1, 2, 3, 4, 5, 5, 4, 3, 2, 1, 0])
+//         },
+//         {
+//             name: "4d_1x2x2x4",
+//             destShape: [1, 2, 2, 4],
+//             sourceShape: [1, 2, 2, 4],
+//             constr: Int32Array,
+//             selection: [slice(null), slice(null), slice(null), slice(null)],
+//             expected: Int32Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+//         },
+//         {
+//             name: "4d_1x2x2x4_step_-1",
+//             destShape: [1, 2, 2, 4],
+//             sourceShape: [1, 2, 2, 4],
+//             constr: Int32Array,
+//             selection: [slice(null), slice(null), slice(null), slice(null, null, -1)],
+//             expected: Int32Array.from([3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12])
+//         },
+//         {
+//             name: "4d_1x2x2x4_step_-1_partial",
+//             destShape: [1, 2, 2, 4],
+//             sourceShape: [1, 1, 2, 4],
+//             constr: Int32Array,
+//             selection: [slice(null), slice(null, 1), slice(null), slice(null, null, -1)],
+//             expected: Int32Array.from([3, 2, 1, 0, 7, 6, 5, 4, 8, 9, 10, 11, 12, 13, 14, 15])
+//         },
+//     ];
+
+
+//     test.each(testCases)(`%p`, (t: TestCase) => {
+//         const sourceData = rangeTypedArray(t.sourceShape, t.constr);
+//         const sourceRawArray = new RawArray(new t.constr(sourceData.buffer), t.sourceShape);
+
+//         const destData = rangeTypedArray(t.destShape, t.constr);
+//         const destRawArray = new RawArray(new t.constr(destData.buffer), t.destShape);
+
+//         setRawArrayDirect(
+//             destRawArray,
+//             destRawArray.strides,
+//             t.destShape,
+//             t.selection,
+//             sourceRawArray,
+//             sourceRawArray.strides,
+//             t.sourceShape,
+
+//         );
+//         expect(destRawArray).toEqual(t.expected);
+//     });
+
+
+// });
+
+describe("RawArray scalar setting", () => {
+    interface TestCase {
+        name: string;
+        destShape: number[];
+        value: number;
+        constr: TypedArrayConstructor<TypedArray>;
+        selection: (Slice | number)[];
+        expected: TypedArray;
+    }
+
+
+    const testCases: TestCase[] = [
+        {
+            name: "1d_3",
+            destShape: [3],
+            value: 2,
+            constr: Int32Array,
+            selection: [slice(null)],
+            expected: Int32Array.from([2, 2, 2]),
+        },
+        {
+            name: "4d_1x2x2x4",
+            destShape: [1, 2, 2, 4],
+            value: 3,
+            constr: Int32Array,
+            selection: [slice(null), slice(0, 1), slice(null), slice(null)],
+            expected: Int32Array.from([3, 3, 3, 3, 3, 3, 3, 3, 8, 9, 10, 11, 12, 13, 14, 15])
+        },
+        {
+            name: "4d_1x2x2x4_step_2",
+            destShape: [1, 2, 2, 4],
+            value: 3,
+            constr: Int32Array,
+            selection: [slice(null), slice(0, 1), slice(null), slice(null, null, 2)],
+            expected: Int32Array.from([3, 1, 3, 3, 3, 5, 3, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        },
+    ];
+
+
+    test.each(testCases)(`%p`, (t: TestCase) => {
+        const destData = rangeTypedArray(t.destShape, t.constr);
+        const destRawArray = new RawArray(new t.constr(destData.buffer), t.destShape);
+
+        if (t.name === "4d_1x2x2x4_step_2") {
+            console.log(t.name);
+        }
+        setRawArrayToScalar(destRawArray.data, destRawArray.strides, t.destShape, t.selection, t.value);
+        expect(destRawArray.data).toEqual(t.expected);
+    });
+
+});

--- a/test/rawArray/ops.setting.test.ts
+++ b/test/rawArray/ops.setting.test.ts
@@ -5,163 +5,119 @@ import { Slice } from "../../src/core/types";
 import { slice } from "../../src/core/slice";
 import { RawArray } from "../../src/rawArray";
 
-// describe("RawArray setting", () => {
-//     interface TestCase {
-//         name: string;
-//         destShape: number[];
-//         sourceShape: number[];
-//         constr: TypedArrayConstructor<TypedArray>;
-//         selection: (Slice | number)[];
-//         expected: TypedArray;
-//     }
+describe("RawArray setting", () => {
+    interface TestCase {
+        name: string;
+        destShape: number[];
+        sourceShape: number[];
+        constr: TypedArrayConstructor<TypedArray>;
+        destSelection: (Slice | number)[];
+        sourceSelection: (Slice | number)[];
+        expected: TypedArray;
+    }
 
 
-//     const testCases: TestCase[] = [
-//         {
-//             name: "1d_3",
-//             destShape: [3],
-//             sourceShape: [3],
-//             constr: Int32Array,
-//             selection: [slice(null)],
-//             expected: Int32Array.from([0, 1, 2]),
-//         },
-//         {
-//             name: "1d_3",
-//             destShape: [3],
-//             sourceShape: [2],
-//             constr: Int32Array,
-//             selection: [slice(1, 3)],
-//             expected: Int32Array.from([0, 0, 1]),
-//         },
-//         {
-//             name: "1d_3_step_-1",
-//             destShape: [3],
-//             sourceShape: [2],
-//             constr: Int32Array,
-//             selection: [slice(2, 0, -1)],
-//             expected: Int32Array.from([0, 1, 0]),
-//         },
-//         {
-//             name: "1d_3_step_2",
-//             destShape: [3],
-//             sourceShape: [2],
-//             constr: Int32Array,
-//             selection: [slice(0, null, 2)],
-//             expected: Int32Array.from([0, 1, 1]),
-//         },
-//         {
-//             name: "1d_5_step_-3",
-//             destShape: [5],
-//             sourceShape: [3],
-//             constr: Int32Array,
-//             selection: [slice(null, null, -2)],
-//             expected: Int32Array.from([2, 1, 1, 3, 0]),
-//         },
-//         {
-//             name: "2d_2x3",
-//             destShape: [2, 3],
-//             sourceShape: [2, 3],
-//             constr: Int32Array,
-//             selection: [slice(null)],
-//             expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
-//         },
-//         {
-//             name: "2d_2x3_s",
-//             destShape: [2, 3],
-//             sourceShape: [3],
-//             constr: Int32Array,
-//             selection: [0],
-//             expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
-//         },
-//         {
-//             name: "2d_2x3_s",
-//             destShape: [2, 3],
-//             sourceShape: [2],
-//             constr: Int32Array,
-//             selection: [slice(null), 0],
-//             expected: Int32Array.from([0, 1, 2, 1, 4, 5])
-//         },
-//         {
-//             name: "2d_2x3_int_index",
-//             destShape: [2, 3],
-//             sourceShape: [3],
-//             constr: Int32Array,
-//             selection: [1],
-//             expected: Int32Array.from([0, 1, 2, 0, 1, 2]),
-//         },
-//         {
-//             name: "2d_2x3_int_index_step_-1",
-//             destShape: [2, 3],
-//             sourceShape: [3],
-//             constr: Int32Array,
-//             selection: [1, slice(null, null, -1)],
-//             expected: Int32Array.from([0, 1, 2, 2, 1, 0]),
-//         },
-//         {
-//             name: "2d_2x3_empty",
-//             destShape: [2, 3],
-//             sourceShape: [0, 3],
-//             constr: Int32Array,
-//             selection: [slice(0, 0)],
-//             expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
-//         },
-//         {
-//             name: "5d_1x2x1x2x3_int_index_negative_slice",
-//             destShape: [1, 2, 1, 2, 3],
-//             sourceShape: [2, 3],
-//             constr: Int32Array,
-//             selection: [0, 1, 0, slice(null, null, -1), slice(null, null, -1)],
-//             expected: Int32Array.from([0, 1, 2, 3, 4, 5, 5, 4, 3, 2, 1, 0])
-//         },
-//         {
-//             name: "4d_1x2x2x4",
-//             destShape: [1, 2, 2, 4],
-//             sourceShape: [1, 2, 2, 4],
-//             constr: Int32Array,
-//             selection: [slice(null), slice(null), slice(null), slice(null)],
-//             expected: Int32Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
-//         },
-//         {
-//             name: "4d_1x2x2x4_step_-1",
-//             destShape: [1, 2, 2, 4],
-//             sourceShape: [1, 2, 2, 4],
-//             constr: Int32Array,
-//             selection: [slice(null), slice(null), slice(null), slice(null, null, -1)],
-//             expected: Int32Array.from([3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12])
-//         },
-//         {
-//             name: "4d_1x2x2x4_step_-1_partial",
-//             destShape: [1, 2, 2, 4],
-//             sourceShape: [1, 1, 2, 4],
-//             constr: Int32Array,
-//             selection: [slice(null), slice(null, 1), slice(null), slice(null, null, -1)],
-//             expected: Int32Array.from([3, 2, 1, 0, 7, 6, 5, 4, 8, 9, 10, 11, 12, 13, 14, 15])
-//         },
-//     ];
+    const testCases: TestCase[] = [
+        {
+            name: "1d_3",
+            destShape: [3],
+            sourceShape: [3],
+            constr: Int32Array,
+            destSelection: [slice(null)],
+            sourceSelection: [slice(null)],
+            expected: Int32Array.from([0, 1, 2]),
+        },
+        {
+            name: "1d_3",
+            destShape: [3],
+            sourceShape: [2],
+            constr: Int32Array,
+            destSelection: [slice(1, 3)],
+            sourceSelection: [slice(null)],
+            expected: Int32Array.from([0, 0, 1]),
+        },
+        {
+            name: "1d_3_step_2",
+            destShape: [3],
+            sourceShape: [2],
+            constr: Int32Array,
+            destSelection: [slice(0, null, 2)],
+            sourceSelection: [slice(null)],
+            expected: Int32Array.from([0, 1, 1]),
+        },
+        {
+            name: "2d_2x3",
+            destShape: [2, 3],
+            sourceShape: [2, 3],
+            constr: Int32Array,
+            destSelection: [slice(null)],
+            sourceSelection: [slice(null)],
+            expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
+        },
+        {
+            name: "2d_2x3_s",
+            destShape: [2, 3],
+            sourceShape: [3],
+            constr: Int32Array,
+            destSelection: [0],
+            sourceSelection: [slice(null)],
+            expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
+        },
+        {
+            name: "2d_2x3_s",
+            destShape: [2, 3],
+            sourceShape: [2],
+            constr: Int32Array,
+            destSelection: [slice(null), 0],
+            sourceSelection: [slice(null)],
+            expected: Int32Array.from([0, 1, 2, 1, 4, 5])
+        },
+        {
+            name: "2d_2x3_empty",
+            destShape: [2, 3],
+            sourceShape: [0, 3],
+            constr: Int32Array,
+            destSelection: [slice(0, 0)],
+            sourceSelection: [slice(null)],
+            expected: Int32Array.from([0, 1, 2, 3, 4, 5]),
+        },
+        {
+            name: "4d_1x2x2x4",
+            destShape: [1, 2, 2, 4],
+            sourceShape: [1, 2, 2, 4],
+            constr: Int32Array,
+            destSelection: [slice(null), slice(null), slice(null), slice(null)],
+            sourceSelection: [slice(null), slice(null), slice(null), slice(null)],
+            expected: Int32Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        },
+    ];
 
 
-//     test.each(testCases)(`%p`, (t: TestCase) => {
-//         const sourceData = rangeTypedArray(t.sourceShape, t.constr);
-//         const sourceRawArray = new RawArray(new t.constr(sourceData.buffer), t.sourceShape);
+    test.each(testCases)(`%p`, (t: TestCase) => {
+        const sourceData = rangeTypedArray(t.sourceShape, t.constr);
+        const sourceRawArray = new RawArray(new t.constr(sourceData.buffer), t.sourceShape);
 
-//         const destData = rangeTypedArray(t.destShape, t.constr);
-//         const destRawArray = new RawArray(new t.constr(destData.buffer), t.destShape);
+        const destData = rangeTypedArray(t.destShape, t.constr);
+        const destRawArray = new RawArray(new t.constr(destData.buffer), t.destShape);
 
-//         setRawArrayDirect(
-//             destRawArray,
-//             destRawArray.strides,
-//             t.destShape,
-//             t.selection,
-//             sourceRawArray,
-//             sourceRawArray.strides,
-//             t.sourceShape,
+        setRawArrayDirect(
+            destRawArray.data,
+            destRawArray.strides,
+            t.destShape,
+            t.destSelection,
+            sourceRawArray.data,
+            sourceRawArray.strides,
+            t.sourceShape,
+            t.sourceSelection
+        );
+        if (t.name === "4d_1x2x2x4_step_2") {
+            console.warn('here');
+        }
+        expect(destRawArray.data).toEqual(t.expected);
+    });
 
-//         );
-//         expect(destRawArray).toEqual(t.expected);
-//     });
 
-
-// });
+});
 
 describe("RawArray scalar setting", () => {
     interface TestCase {
@@ -205,10 +161,6 @@ describe("RawArray scalar setting", () => {
     test.each(testCases)(`%p`, (t: TestCase) => {
         const destData = rangeTypedArray(t.destShape, t.constr);
         const destRawArray = new RawArray(new t.constr(destData.buffer), t.destShape);
-
-        if (t.name === "4d_1x2x2x4_step_2") {
-            console.log(t.name);
-        }
         setRawArrayToScalar(destRawArray.data, destRawArray.strides, t.destShape, t.selection, t.value);
         expect(destRawArray.data).toEqual(t.expected);
     });


### PR DESCRIPTION
Adds feature #15 !

Ok, so this was a bit of a doozy, but things are working! 

I created a `RawArray` interface for writing to a single _strided_ `TypedArray` from "C" ordering. The following API is exposed to the end user:

```javascript
import { openArray, slice } from 'zarr';

const config = {
  store: 'http://localhost:5000',
  path: 'dummy_data.zarr',
};

const selection = [
    null, 
    slice(null, 512), 
    slice(null, null, 2)
];

const z = await openArray(config);
const rawArray = await z.getRaw(selection [, getOptions ]);

const { data, shape, strides } = rawArray; // data is single TypedArray

const arr = tf.tensor(data, shape); // tensorflow.js
const arr2 = ndarray(data, shape) ; // ndarray
```

## Technical details

When indexing the `ZarrStore`, `getRaw` works by creating a single `RawArray` as output. 

For each projection of the `indexer`,

- Entire chunk is fetched and decoded (like in `.get`), 
- The destination selection is used to index the output array while the chunk selection is used to index the `TypedArray` chunk to fill the output, rather than making a temporary array.

The final result is a `RawArray` with properties:
- `data`: Single strided `TypedArray` (e.g. `Int32Array(786432) [ 0, 1, 2, … ]`)
- `dtype`: Datatype string from zarr (e.g. `"<i4"`)
- `shape`: Array of dimension sizes (e.g. `[3, 512, 512]`)
- `strides`: Number of elements to jump per dimension (e.g. `[262144, 512, 1]`)

## Notes
- ~~One optimization that I haven't implemented yet is adding a check for whether a chunk _is_ exactly the desired selection. Rather than copying that entire chunk to the output, we should just directly return the decoded chunk (since it is already strided due to zarr).~~
- This is something we are interested in particularly with tiling image data. Tile-sizes === chunk sizes in our image pyramids, and this optimization would effectively make 1 request per tile 👍 
- Edit: I have now added this