### PR TITLE
Get raw chunk by index

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -7,11 +7,11 @@ import { ARRAY_META_KEY, ATTRS_META_KEY } from '../names';
 import { Attributes } from "../attributes";
 import { parseMetadata } from "../metadata";
 import { ArraySelection, DimensionSelection, Indexer, Slice, ChunkProjection } from "./types";
-import { BasicIndexer, isContiguousSelection } from './indexing';
+import { BasicIndexer, isContiguousSelection, normalizeIntegerSelection } from './indexing';
 import { NestedArray } from "../nestedArray";
 import { RawArray } from "../rawArray";
 import { TypedArray, DTYPE_TYPEDARRAY_MAPPING } from '../nestedArray/types';
-import { ValueError, PermissionError, KeyError } from '../errors';
+import { ValueError, PermissionError, KeyError, BoundsCheckError } from '../errors';
 import { Codec } from "../compression/types";
 import { getCodec } from "../compression/creation";
 
@@ -421,11 +421,16 @@ export class ZarrArray {
     if (chunkCoords.length !== this.shape.length) {
       throw new Error(`Chunk coordinates ${chunkCoords.join(".")} do not correspond to shape ${this.shape}.`);
     }
-    for (let i = 0; i < chunkCoords.length; i++) {
-      const coordIndex = chunkCoords[i];
-      const maxCoordIndex = Math.ceil(this.shape[i] / this.chunks[i]) - 1;
-      if (coordIndex > maxCoordIndex) {
-        throw new Error(`Chunk index ${chunkCoords.join(".")} is out of bounds for store with shape: ${this.shape} and chunks ${this.chunks}`);
+    try {
+      for (let i = 0; i < chunkCoords.length; i++) {
+        const dimLength = Math.ceil(this.shape[i] / this.chunks[i]);
+        chunkCoords[i] = normalizeIntegerSelection(chunkCoords[i], dimLength);
+      }
+    } catch (error) {
+      if (error instanceof BoundsCheckError) {
+        throw new Error(`${error.name} : index ${chunkCoords.join(".")} is out of bounds for shape: ${this.shape} and chunks ${this.chunks}`);
+      } else {
+        throw new error;
       }
     }
     const cKey = this.chunkKey(chunkCoords);
@@ -456,7 +461,7 @@ export class ZarrArray {
     return new NestedArray<T>(buffer, this.chunks, this.dtype);
   }
 
-  public decodeChunk(chunkData: ValidStoreType) {
+  private decodeChunk(chunkData: ValidStoreType) {
     const byteChunkData = this.ensureByteArray(chunkData);
 
     if (this.compressor !== null) {

--- a/test/core/indexing.test.ts
+++ b/test/core/indexing.test.ts
@@ -7,6 +7,8 @@ import { NestedArray, rangeTypedArray } from '../../src/nestedArray/index';
 import { create } from '../../src/creation';
 import { TypedArray } from "../../src/nestedArray/types";
 import { MemoryStore } from "../../src/storage/memoryStore";
+import { getStrides } from "../../src/util";
+import { stringify } from "querystring";
 
 describe("normalizeIntegerSelection", () => {
     it("normalizes integer selections", () => {
@@ -267,26 +269,48 @@ async function testGetBasicSelectionRaw(z: ZarrArray, selection: any, data: Nest
 
 
 describe("GetRawChunk", () => {
-    const chunkCoords = [
-        // [[0, 0]],
-        // [[1, 1]],
-        // [[1, 2]],
-        // [[2, 2]],
-        // [[2, 1]],
-        [[0, 3]]
+    const basicChunkCoords1D: any[] = [
+        [[0]], [[1]], [[2]], [[6]], [[7]], [[10]]
     ];
+
+    const data = rangeTypedArray([1050], Int32Array);
+    const nestedArr = new NestedArray(data, [1050], "<i4");
+
+    test.each(basicChunkCoords1D)(`%p`, async (coords) => {
+        const z = await create({ shape: nestedArr.shape, chunks: [100], dtype: nestedArr.dtype });
+        await z.set(null, nestedArr);
+        await testGetRawChunk(z, coords, nestedArr, 'x');
+    });
+});
+
+describe("getRawChunk2D", () => {
+    interface TestCase {
+        chunkCoords: number[];
+        pad?: string;
+    }
+
+    const testCases: TestCase[] = [
+        { chunkCoords: [0, 0] },
+        { chunkCoords: [0, 1] },
+        { chunkCoords: [1, 1] },
+        { chunkCoords: [2, 1], pad: 'x' },
+        { chunkCoords: [2, 2], pad: 'x' },
+        { chunkCoords: [0, 3], pad: 'y' },
+        { chunkCoords: [1, 3], pad: 'y' }
+    ];
+
 
     const data = rangeTypedArray([1000, 10], Int32Array);
     const nestedArr = new NestedArray(data, [1000, 10], "<i4");
 
-    test.each(chunkCoords)(`%p`, async (coords) => {
+    test.each(testCases)(`%p`, async (t) => {
         const z = await create({ shape: nestedArr.shape, chunks: [400, 3], dtype: nestedArr.dtype });
         await z.set(null, nestedArr);
-        await testGetRawChunk(z, coords, nestedArr);
+        await testGetRawChunk(z, t.chunkCoords, nestedArr, t.pad);
     });
 });
 
-async function testGetRawChunk(z: ZarrArray, chunkCoords: number[], data: NestedArray<TypedArray>) {
+async function testGetRawChunk(z: ZarrArray, chunkCoords: number[], data: NestedArray<TypedArray>, padDim?: string) {
     const decodedChunk = await z.getRawChunk(chunkCoords);
     const selection = [];
     for (let i = 0; i < chunkCoords.length; i++) {
@@ -294,7 +318,26 @@ async function testGetRawChunk(z: ZarrArray, chunkCoords: number[], data: Nested
         const coord = chunkCoords[i];
         selection.push(slice(coord * dimChunkSize, dimChunkSize * (coord + 1)));
     }
-    const selectedFromSource = (await data.get(selection)).flatten();
-    // expect((decodedChunk as TypedArray).subarray(0, selectedFromSource.length)).toEqual(selectedFromSource);
-    expect(decodedChunk as TypedArray).toEqual(selectedFromSource);
+
+    const selectedFromSource = await data.get(selection);
+    const flattened = selectedFromSource.flatten();
+
+    if (padDim) {
+        // raw chunks will be zero-padded so need to pad source selection
+        const zeroPadded = new Int32Array(decodedChunk.length);
+        if (padDim === 'x') {
+            zeroPadded.set(flattened);
+        } else if (padDim === 'y') {
+            const chunkStrides = getStrides(z.chunks);
+            const dataStrides = getStrides(selectedFromSource.shape);
+            for (let i = 0; i < selectedFromSource.shape[0]; i++) {
+                const view = flattened.subarray(dataStrides[0] * i, dataStrides[0] * i + selectedFromSource.shape[1]);
+                zeroPadded.set(view, chunkStrides[0] * i);
+            }
+        }
+        expect(decodedChunk).toEqual(zeroPadded);
+    } else {
+        expect(decodedChunk).toEqual(flattened);
+    }
 }
+

--- a/test/core/indexing.test.ts
+++ b/test/core/indexing.test.ts
@@ -324,7 +324,7 @@ async function testGetRawChunk(z: ZarrArray, chunkCoords: number[], data: Nested
 
     if (padDim) {
         // raw chunks will be zero-padded so need to pad source selection
-        const zeroPadded = new Int32Array(decodedChunk.length);
+        const zeroPadded = new Int32Array(decodedChunk.data.length);
         if (padDim === 'x') {
             zeroPadded.set(flattened);
         } else if (padDim === 'y') {
@@ -335,9 +335,9 @@ async function testGetRawChunk(z: ZarrArray, chunkCoords: number[], data: Nested
                 zeroPadded.set(view, chunkStrides[0] * i);
             }
         }
-        expect(decodedChunk).toEqual(zeroPadded);
+        expect(decodedChunk.data).toEqual(zeroPadded);
     } else {
-        expect(decodedChunk).toEqual(flattened);
+        expect(decodedChunk.data).toEqual(flattened);
     }
 }
 

--- a/test/core/indexing.test.ts
+++ b/test/core/indexing.test.ts
@@ -8,7 +8,6 @@ import { create } from '../../src/creation';
 import { TypedArray } from "../../src/nestedArray/types";
 import { MemoryStore } from "../../src/storage/memoryStore";
 import { getStrides } from "../../src/util";
-import { stringify } from "querystring";
 
 describe("normalizeIntegerSelection", () => {
     it("normalizes integer selections", () => {
@@ -293,10 +292,13 @@ describe("getRawChunk2D", () => {
         { chunkCoords: [0, 0] },
         { chunkCoords: [0, 1] },
         { chunkCoords: [1, 1] },
+        { chunkCoords: [1, -2] },
         { chunkCoords: [2, 1], pad: 'x' },
         { chunkCoords: [2, 2], pad: 'x' },
+        { chunkCoords: [-1, 2], pad: 'x' },
         { chunkCoords: [0, 3], pad: 'y' },
-        { chunkCoords: [1, 3], pad: 'y' }
+        { chunkCoords: [1, 3], pad: 'y' },
+        { chunkCoords: [1, -1], pad: 'y' }
     ];
 
 


### PR DESCRIPTION
I'm working on a small utility built on top of zarr.js to decoding tiled image pyramids saved in zarr. To this end, I don't want to keep track of indices but rather request the chunks directly by index. 

I found that I wanted the following in my project:

```javascript
async function getTile(chunkCoords) {
    const key = z.chunkKey(chunkCoords);
    const cdata = await z.getChunkItem(key);
    const decoded = z.decodeChunk(cdata);
    const data = z.toTypedArray(decoded);
    return data
}
```
But many of these methods are private. I basically wrapped this paradigm into a function `getRawChunk` which returns a ~typed array~ `RawArray`. ~I guess I could change it to `RawArray` with a notion of `shape` and `strides` might be useful~. For edges, the raw tiles return zero-padded from the decoder. 