### PR TITLE
throw KeyError on 404 in HTTPStore; removes duplicate requests.

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -378,6 +378,8 @@ export class ZarrArray {
     const cKey = this.chunkKey(chunkCoords);
     try {
       const cdata = await this.chunkStore.getItem(cKey);
+      const decodedChunk = this.decodeChunk(cdata);
+
       if (out instanceof NestedArray) {
 
         if (isContiguousSelection(outSelection) && isTotalSlice(chunkSelection, this.chunks) && !this.meta.filters) {
@@ -387,12 +389,12 @@ export class ZarrArray {
 
           // TODO check order
           // TODO filters..
-          out.set(outSelection, this.toNestedArray<T>(this.decodeChunk(cdata)));
+          out.set(outSelection, this.toNestedArray<T>(decodedChunk));
           return;
         }
 
         // Decode chunk
-        const chunk = this.toNestedArray(this.decodeChunk(cdata));
+        const chunk = this.toNestedArray(decodedChunk);
         const tmp = chunk.get(chunkSelection);
 
         if (dropAxes !== null) {
@@ -406,7 +408,7 @@ export class ZarrArray {
         Copies chunk by index directly into output. Doesn't matter if selection is contiguous
         since store/output are different shapes/strides.
         */
-        out.set(outSelection, this.chunkBufferToRawArray(this.decodeChunk(cdata)), chunkSelection);
+        out.set(outSelection, this.chunkBufferToRawArray(decodedChunk), chunkSelection);
       }
 
     } catch (error) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -376,10 +376,8 @@ export class ZarrArray {
     }
 
     const cKey = this.chunkKey(chunkCoords);
-    // TODO may be better to ask for forgiveness instead
-    if (await this.chunkStore.containsItem(cKey)) {
-      const cdata = this.chunkStore.getItem(cKey);
-
+    try {
+      const cdata = await this.chunkStore.getItem(cKey);
       if (out instanceof NestedArray) {
 
         if (isContiguousSelection(outSelection) && isTotalSlice(chunkSelection, this.chunks) && !this.meta.filters) {
@@ -389,12 +387,12 @@ export class ZarrArray {
 
           // TODO check order
           // TODO filters..
-          out.set(outSelection, this.toNestedArray<T>(this.decodeChunk(await cdata)));
+          out.set(outSelection, this.toNestedArray<T>(this.decodeChunk(cdata)));
           return;
         }
 
         // Decode chunk
-        const chunk = this.toNestedArray(this.decodeChunk(await cdata));
+        const chunk = this.toNestedArray(this.decodeChunk(cdata));
         const tmp = chunk.get(chunkSelection);
 
         if (dropAxes !== null) {
@@ -402,17 +400,24 @@ export class ZarrArray {
         }
 
         out.set(outSelection, tmp as NestedArray<T>);
+
       } else {
         /* RawArray
         Copies chunk by index directly into output. Doesn't matter if selection is contiguous
         since store/output are different shapes/strides.
         */
-        out.set(outSelection, this.chunkBufferToRawArray(this.decodeChunk(await cdata)), chunkSelection);
+        out.set(outSelection, this.chunkBufferToRawArray(this.decodeChunk(cdata)), chunkSelection);
       }
 
-    } else { // Chunk isn't there, use fill value
-      if (this.fillValue !== null) {
-        out.set(outSelection, this.fillValue);
+    } catch (error) {
+      if (error instanceof KeyError) {
+        // fill with scalar if cKey doesn't exist in store
+        if (this.fillValue !== null) {
+          out.set(outSelection, this.fillValue);
+        }
+      } else {
+        // Different type of error - rethrow
+        throw new error;
       }
     }
   }
@@ -478,13 +483,18 @@ export class ZarrArray {
 
   private async decodeDirectToRawArray({ chunkCoords }: ChunkProjection, outShape: number[], outSize: number): Promise<RawArray> {
     const cKey = this.chunkKey(chunkCoords);
-    if (await this.chunkStore.containsItem(cKey)) {
+    try {
       const cdata = this.chunkStore.getItem(cKey);
-      // we use outShape here rather than this.chunks because strides will be computed for sqeezed dims
       return new RawArray(this.decodeChunk(await cdata), outShape, this.dtype);
-    } else {
-      const data = new DTYPE_TYPEDARRAY_MAPPING[this.dtype](outSize);
-      return new RawArray(data.fill(this.fillValue as number), outShape);
+    } catch (error) {
+      if (error instanceof KeyError) {
+        // fill with scalar if item doesn't exist
+        const data = new DTYPE_TYPEDARRAY_MAPPING[this.dtype](outSize);
+        return new RawArray(data.fill(this.fillValue as number), outShape);
+      } else {
+        // Different type of error - rethrow
+        throw new error;
+      }
     }
   }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -85,3 +85,10 @@ export class ValueError extends Error {
         Object.setPrototypeOf(this, ValueError.prototype);
     }
 }
+
+export class HTTPError extends Error {
+    constructor(code: string) {
+      super(code);
+      Object.setPrototypeOf(this, HTTPError.prototype);
+    }
+  }

--- a/src/hierarchy.ts
+++ b/src/hierarchy.ts
@@ -278,7 +278,7 @@ export async function group(store?: Store | string, path: string | null = null, 
  * @param chunkStore Store or path to directory in file system or name of zip file.
  * @param cacheAttrs If `true` (default), user attributes will be cached for attribute read operations
  *   If False, user attributes are reloaded from the store prior to all attribute read operations.
- * 
+ *
  */
 export async function openGroup(store?: Store | string, path: string | null = null, mode: PersistenceMode = "a", chunkStore?: Store, cacheAttrs = true) {
     store = normalizeStoreArgument(store);

--- a/src/storage/httpStore.ts
+++ b/src/storage/httpStore.ts
@@ -1,6 +1,6 @@
 import { ValidStoreType, AsyncStore } from './types';
 import { IS_NODE } from '../util';
-import { KeyError } from '../errors';
+import { KeyError, HTTPError } from '../errors';
 
 export class HTTPStore implements AsyncStore<ArrayBuffer> {
     listDir?: undefined;
@@ -25,8 +25,10 @@ export class HTTPStore implements AsyncStore<ArrayBuffer> {
         if (value.status === 404) {
             // Item is not found
             throw new KeyError(item);
+        } else if (value.status !== 200) {
+            throw new HTTPError(String(value.status));
         }
-
+        // only decode if 200
         if (IS_NODE) {
             // Node
             return Buffer.from(await value.arrayBuffer());

--- a/src/storage/httpStore.ts
+++ b/src/storage/httpStore.ts
@@ -1,5 +1,6 @@
 import { ValidStoreType, AsyncStore } from './types';
 import { IS_NODE } from '../util';
+import { KeyError } from '../errors';
 
 export class HTTPStore implements AsyncStore<ArrayBuffer> {
     listDir?: undefined;
@@ -20,6 +21,12 @@ export class HTTPStore implements AsyncStore<ArrayBuffer> {
     async getItem(item: string) {
         const url = new URL(item, this.url).href;
         const value = await fetch(url);
+
+        if (value.status === 404) {
+            // Item is not found
+            throw new KeyError(item);
+        }
+
         if (IS_NODE) {
             // Node
             return Buffer.from(await value.arrayBuffer());


### PR DESCRIPTION
Fixes #10. 

Similar to `MemoryStore` and `ObjectStore` we throw a `KeyError` on 404 in `HttpStore.getItem`. This is slightly different from the `HttpStore.containsItem` which was used before and returns `true` if 200 on request. If the status code is something other than 200 or 404 we throw an `HTTPError` with that code. Thus the buffer is only returned if the status is 200.



