### PR TITLE
Change output module naming to es6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "async"
   ],
   "main": "dist/zarr.umd.js",
-  "module": "dist/zarr.es5.js",
+  "module": "dist/zarr.es6.js",
   "typings": "dist/types/zarr.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
We could instead consider making it `es.js` and just drop the number.