### PR TITLE
Add fetchOptions and supportedMethods to HTTPStore

### DIFF
--- a/docs/getting-started/remote-data.md
+++ b/docs/getting-started/remote-data.md
@@ -17,6 +17,7 @@ If `HEAD` is listed (default), the store will use `HEAD` requests to check for i
 making a full `GET` request and inspecting the response status.
 
 ```javascript
+import { HTTPStore } from 'zarr';
 const fetchOptions = { redirect: 'follow', headers: { 'custom-header': 'value' } };
 const supportedMethods = ['GET', 'PUT', 'HEAD']; // defaults
 const store = new HTTPStore('http://localhost:8000', { fetchOptions, supportedMethods });

--- a/docs/getting-started/remote-data.md
+++ b/docs/getting-started/remote-data.md
@@ -7,6 +7,21 @@ Zarr abstracts over different backend stores where the data lives.
 * `MemoryStore`: Data is stored in a nested in-memory Javascript object.
 * `HTTPStore`: Data is stored at some remote prefix (e.g. `localhost:1234/my_dataset.zarr`). This would also work for zarr datasets stored in public buckets.
 
+The `HTTPStore` uses [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) internally
+to get and set chunks via HTTP requests. To have more granular control over over these requests
+(e.g. setting headers, etc), you can specify request options when initializing the store.
+These options are forwarded to each fetch request made internally by the store. 
+
+Additionally, you may supply `supportedMethods` which defines which HTTP methods a given store supports.
+If `HEAD` is listed (default), the store will use `HEAD` requests to check for items rather than checking
+the response status for a full `GET` request.
+
+```javascript
+const fetchOptions = { redirect: 'follow', headers: { 'custom-header': 'value' } };
+const supportedMethods = ['GET', 'PUT', 'HEAD']; // defaults
+const store = new HTTPStore('http://localhost:8000', { fetchOptions, supportedMethods });
+```
+
 # Remote datasets {docsify-ignore}
 
 Most likely when you are using Zarr.js your ZarrArray data will actually live on a remote server in the zarr format, this is exactly the use-case that Zarr.js was created for :).

--- a/docs/getting-started/remote-data.md
+++ b/docs/getting-started/remote-data.md
@@ -9,12 +9,12 @@ Zarr abstracts over different backend stores where the data lives.
 
 The `HTTPStore` uses [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) internally
 to get and set chunks via HTTP requests. To have more granular control over these requests
-(e.g. setting headers, etc), you request options may be supplied when initializing the store.
-These options are forwarded to each fetch request made internally by the store. 
+(e.g. setting headers, etc), request options may be supplied when initializing the store.
+These options are forwarded to each `fetch` call made internally by the store. 
 
-Additionally, you may supply `supportedMethods` which defines which HTTP methods a given store supports.
-If `HEAD` is listed (default), the store will use `HEAD` requests to check for items rather than checking
-the response status for a full `GET` request.
+Additionally, `supportedMethods` specifies which HTTP methods a given store supports.
+If `HEAD` is listed (default), the store will use `HEAD` requests to check for items rather than 
+making a full `GET` request and inspecting the response status.
 
 ```javascript
 const fetchOptions = { redirect: 'follow', headers: { 'custom-header': 'value' } };

--- a/docs/getting-started/remote-data.md
+++ b/docs/getting-started/remote-data.md
@@ -8,8 +8,8 @@ Zarr abstracts over different backend stores where the data lives.
 * `HTTPStore`: Data is stored at some remote prefix (e.g. `localhost:1234/my_dataset.zarr`). This would also work for zarr datasets stored in public buckets.
 
 The `HTTPStore` uses [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) internally
-to get and set chunks via HTTP requests. To have more granular control over over these requests
-(e.g. setting headers, etc), you can specify request options when initializing the store.
+to get and set chunks via HTTP requests. To have more granular control over these requests
+(e.g. setting headers, etc), you request options may be supplied when initializing the store.
 These options are forwarded to each fetch request made internally by the store. 
 
 Additionally, you may supply `supportedMethods` which defines which HTTP methods a given store supports.

--- a/src/storage/httpStore.ts
+++ b/src/storage/httpStore.ts
@@ -79,4 +79,3 @@ export class HTTPStore implements AsyncStore<ArrayBuffer> {
         return value.status === 200;
     }
 }
-

--- a/src/storage/httpStore.ts
+++ b/src/storage/httpStore.ts
@@ -49,10 +49,11 @@ export class HTTPStore implements AsyncStore<ArrayBuffer> {
     deleteItem(_item: string): Promise<boolean> {
         throw new Error('Method not implemented.');
     }
+
     async containsItem(item: string): Promise<boolean> {
         const url = joinUrlParts(this.url, item);
-        const value = await fetch(url);
-
+        // Use HEAD method just to get headers
+        const value = await fetch(url, { method: 'HEAD' });
         return value.status === 200;
     }
 }

--- a/src/storage/httpStore.ts
+++ b/src/storage/httpStore.ts
@@ -63,7 +63,7 @@ export class HTTPStore implements AsyncStore<ArrayBuffer> {
         if (typeof value === 'string') {
             value = new TextEncoder().encode(value).buffer;
         }
-        const set = await fetch(url, {...this.fetchOptions, method: HTTPMethod.PUT, body: value });
+        const set = await fetch(url, { ...this.fetchOptions, method: HTTPMethod.PUT, body: value });
         return set.status.toString()[0] === '2';
     }
 


### PR DESCRIPTION
If we just want to check if an item exists in a store, we can just make a requests for the headers (no body) and check the status code. However, this probably negates caching of these items in the browser, which might be a worse than what we have currently. Thoughts?