### PR TITLE
Export "zarr/core" package export without codecs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,12 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
     "@babel/highlight": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
@@ -1645,6 +1651,12 @@
         "webidl-conversions": "^4.0.2"
       }
     },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -2319,6 +2331,16 @@
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -3256,6 +3278,15 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
+    },
+    "gzip-size": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+      "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.1"
+      }
     },
     "handlebars": {
       "version": "4.5.3",
@@ -5576,6 +5607,60 @@
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
       "dev": true
     },
+    "maxmin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-2.1.0.tgz",
+      "integrity": "sha1-TTsiCQPZXu5+t6x/qGTnLcCaMWY=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "figures": "^1.0.1",
+        "gzip-size": "^3.0.0",
+        "pretty-bytes": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6381,6 +6466,15 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "pretty-bytes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+      "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
     "pretty-format": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
@@ -6553,6 +6647,15 @@
           "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
           "dev": true
         }
+      }
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -7001,6 +7104,58 @@
         "acorn": "^7.1.0"
       }
     },
+    "rollup-plugin-bundle-size": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-bundle-size/-/rollup-plugin-bundle-size-1.0.3.tgz",
+      "integrity": "sha512-aWj0Pvzq90fqbI5vN1IvUrlf4utOqy+AERYxwWjegH1G8PzheMnrRIgQ5tkwKVtQMDP0bHZEACW/zLDF+XgfXQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "maxmin": "^2.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "rollup-plugin-sourcemaps": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.4.2.tgz",
@@ -7009,6 +7164,78 @@
       "requires": {
         "rollup-pluginutils": "^2.0.1",
         "source-map-resolve": "^0.5.0"
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "merge-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "rollup-plugin-typescript2": {
@@ -7258,6 +7485,15 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
+      }
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "serve-static": {
@@ -7792,6 +8028,43 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "terser": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.4.tgz",
+      "integrity": "sha512-dxuB8KQo8Gt6OVOeLg/rxfcxdNZI/V1G6ze1czFUzPeCFWZRtvZMgSzlZZ5OYBZ4HoG607F6pFPNLekJyV+yVw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,15 +98,6 @@
         }
       }
     },
-    "@rollup/plugin-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.0.2.tgz",
-      "integrity": "sha512-t4zJMc98BdH42mBuzjhQA7dKh0t4vMJlUka6Fz0c+iO5IVnWaEMiYBy1uBj9ruHZzXBW23IPDGL9oCzBkQ9Udg==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.0.4"
-      }
-    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.1.tgz",
@@ -7016,16 +7007,6 @@
         "acorn": "^7.1.0"
       }
     },
-    "rollup-plugin-sourcemaps": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.4.2.tgz",
-      "integrity": "sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=",
-      "dev": true,
-      "requires": {
-        "rollup-pluginutils": "^2.0.1",
-        "source-map-resolve": "^0.5.0"
-      }
-    },
     "rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -7209,15 +7190,6 @@
             "estree-walker": "^0.6.1"
           }
         }
-      }
-    },
-    "rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
-      "requires": {
-        "estree-walker": "^0.6.1"
       }
     },
     "rsvp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1651,12 +1651,6 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -2331,16 +2325,6 @@
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
-      }
-    },
-    "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -3278,15 +3262,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
-    },
-    "gzip-size": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
-      "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
-      "dev": true,
-      "requires": {
-        "duplexer": "^0.1.1"
-      }
     },
     "handlebars": {
       "version": "4.5.3",
@@ -5607,60 +5582,6 @@
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
       "dev": true
     },
-    "maxmin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-2.1.0.tgz",
-      "integrity": "sha1-TTsiCQPZXu5+t6x/qGTnLcCaMWY=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.0.0",
-        "figures": "^1.0.1",
-        "gzip-size": "^3.0.0",
-        "pretty-bytes": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6466,15 +6387,6 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
-    "pretty-bytes": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
-      "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
     "pretty-format": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
@@ -7102,58 +7014,6 @@
         "@types/estree": "*",
         "@types/node": "*",
         "acorn": "^7.1.0"
-      }
-    },
-    "rollup-plugin-bundle-size": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-bundle-size/-/rollup-plugin-bundle-size-1.0.3.tgz",
-      "integrity": "sha512-aWj0Pvzq90fqbI5vN1IvUrlf4utOqy+AERYxwWjegH1G8PzheMnrRIgQ5tkwKVtQMDP0bHZEACW/zLDF+XgfXQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "maxmin": "^2.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "rollup-plugin-sourcemaps": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "types/*",
     "core.mjs",
     "core.mjs.map",
-    "core.cjs",
-    "core.cjs.map",
     "zarr.mjs",
     "zarr.mjs.map",
     "zarr.cjs",
@@ -23,14 +21,19 @@
     "zarr.umd.js",
     "zarr.umd.js.map"
   ],
+  "sideEffects": false,
   "main": "zarr.cjs",
   "module": "zarr.mjs",
-  "umd": "zarr.umd.js",
+  "umd:main": "zarr.umd.js",
   "typings": "types/zarr.d.ts",
   "exports": {
+    ".": {
+      "umd": "./zarr.umd.js",
+      "import": "./zarr.mjs",
+      "require": "./zarr.cjs"
+    },
     "./core": {
-      "import": "./core.mjs",
-      "require": "./core.cjs"
+      "import": "./core.mjs"
     }
   },
   "author": "Guido Zuidhof <me@guido.io>",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.2",
-    "@rollup/plugin-json": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@types/express": "^4.17.2",
     "@types/jest": "^23.3.2",
@@ -85,7 +84,6 @@
     "replace-in-file": "^3.4.2",
     "rimraf": "^2.6.2",
     "rollup": "^1.32.0",
-    "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.24.3",
     "serve-static": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "main": "dist/zarr.umd.js",
   "module": "dist/zarr.es6.js",
   "typings": "dist/types/zarr.d.ts",
+  "exports": {
+    "./core": "dist/zarr-core.es6.js"
+  },
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -9,15 +9,24 @@
     "utility",
     "async"
   ],
-  "main": "dist/zarr.umd.js",
-  "module": "dist/zarr.es6.js",
-  "typings": "dist/types/zarr.d.ts",
-  "exports": {
-    "./core": "dist/zarr-core.es6.js"
-  },
   "files": [
-    "dist"
+    "lib/*",
+    "types/*",
+    "core.mjs",
+    "core.mjs.map",
+    "core.cjs",
+    "core.cjs.map",
+    "zarr.mjs",
+    "zarr.mjs.map",
+    "zarr.cjs",
+    "zarr.cjs.map",
+    "zarr.umd.js",
+    "zarr.umd.js.map"
   ],
+  "main": "zarr.cjs",
+  "module": "zarr.mjs",
+  "umd": "zarr.umd.js",
+  "typings": "types/zarr.d.ts",
   "author": "Guido Zuidhof <me@guido.io>",
   "repository": {
     "type": "git",
@@ -37,7 +46,9 @@
     "test:watch": "jest --coverage --watch",
     "test:prod": "npm run lint && npm run test -- --no-cache && jest --config=jest-browser.config.js --no-cache",
     "generate-typedocs": "typedoc --out docs/typedocs --target es6 --theme minimal --readme none --mode file src",
-    "report-coverage": "cat ./coverage/lcov.info | coveralls"
+    "report-coverage": "cat ./coverage/lcov.info | coveralls",
+    "prepublishOnly": "npm run build && cp -r ./dist/* .",
+    "postpublish": "git clean -fd"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.2",
@@ -65,7 +76,9 @@
     "replace-in-file": "^3.4.2",
     "rimraf": "^2.6.2",
     "rollup": "^1.32.0",
+    "rollup-plugin-bundle-size": "^1.0.3",
     "rollup-plugin-sourcemaps": "^0.4.2",
+    "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.24.3",
     "serve-static": "^1.14.1",
     "ts-interface-builder": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     }
   },
   "author": "Guido Zuidhof <me@guido.io>",
+  "contributors": [
+    "Trevor Manz <trevor.j.manz@gmail.com>"
+  ],
   "repository": {
     "type": "git",
     "url": "github.com/gzuidhof/zarr.js"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,12 @@
   "module": "zarr.mjs",
   "umd": "zarr.umd.js",
   "typings": "types/zarr.d.ts",
+  "exports": {
+    "./core": {
+      "import": "./core.mjs",
+      "require": "./core.cjs"
+    }
+  },
   "author": "Guido Zuidhof <me@guido.io>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "replace-in-file": "^3.4.2",
     "rimraf": "^2.6.2",
     "rollup": "^1.32.0",
-    "rollup-plugin-bundle-size": "^1.0.3",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.24.3",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -5,10 +5,7 @@ import { terser } from 'rollup-plugin-terser';
 
 export default [
   {
-    input: {
-      zarr: 'src/zarr.ts',
-      core: 'src/zarr-core.ts',
-    },
+    input: { zarr: 'src/zarr.ts', core: 'src/zarr-core.ts' },
     output: {
       dir: 'dist/',
       format: 'es',
@@ -18,34 +15,21 @@ export default [
     watch: {
       include: 'src/**',
     },
-    plugins: [
-      typescript({ useTsconfigDeclarationDir: true }),
-      commonjs(),
-      resolve(),
-    ],
+    plugins: [typescript({ useTsconfigDeclarationDir: true }), commonjs(), resolve()],
   },
   {
     input: 'src/zarr.ts',
-    output: {
-      file: 'dist/zarr.cjs',
-      format: 'cjs',
-      sourcemap: true
-    },
-    plugins: [
-      typescript({ useTsconfigDeclarationDir: true }),
-      commonjs(),
-      resolve(),
+    output: [
+      { file: 'dist/zarr.cjs', format: 'cjs', sourcemap: true },
+      {
+        file: 'dist/zarr.umd.js',
+        name: 'zarr',
+        format: 'umd',
+        sourcemap: true,
+        esModule: false,
+        plugins: [terser()],
+      },
     ],
-  },
-  {
-    input: 'src/zarr.ts',
-    output: {
-      file: 'dist/zarr.umd.js',
-      name: 'zarr',
-      format: 'umd',
-      sourcemap: true,
-      esModule: false,
-    },
     plugins: [
       typescript({
         useTsconfigDeclarationDir: true,
@@ -54,7 +38,6 @@ export default [
       }),
       commonjs(),
       resolve(),
-      terser(),
     ],
-  }
+  },
 ];

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -8,30 +8,42 @@ const pkg = require('./package.json');
 
 const libraryName = 'zarr';
 
-export default {
-  input: `src/${libraryName}.ts`,
-  output: [
-    { file: pkg.main, name: libraryName, format: 'umd', sourcemap: true },
-    { file: pkg.module, format: 'es', sourcemap: true },
-  ],
-  // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
-  external: [],
-  watch: {
-    include: 'src/**',
-  },
-  plugins: [
-    // Allow json resolution
-    json(),
-    // Compile TypeScript files
-    typescript({ useTsconfigDeclarationDir: true }),
-    // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
-    commonjs(),
-    // Allow node_modules resolution, so you can use 'external' to control
-    // which external modules to include in the bundle
-    // https://github.com/rollup/rollup-plugin-node-resolve#usage
-    resolve(),
+const config = ({ input, output }) => {
+  return {
+    input,
+    output,
+    watch: {
+      include: 'src/**',
+    },
+    plugins: [
+      // Allow json resolution
+      json(),
+      // Compile TypeScript files
+      typescript({ useTsconfigDeclarationDir: true }),
+      // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
+      commonjs(),
+      // Allow node_modules resolution, so you can use 'external' to control
+      // which external modules to include in the bundle
+      // https://github.com/rollup/rollup-plugin-node-resolve#usage
+      resolve(),
+      // Resolve source maps to the original source
+      sourceMaps(),
+    ],
+  }
+}
 
-    // Resolve source maps to the original source
-    sourceMaps(),
-  ],
-};
+export default [
+  config({
+    input: `src/${libraryName}.ts`,
+    output: [
+      { file: pkg.main, name: libraryName, format: 'umd', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true },
+    ],
+  }),
+  config({
+    input: "src/zarr-core.ts",
+    output: {
+      file: pkg.exports['./core'], format: 'es', sourcemap: true
+    }
+  })
+];

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,7 +1,6 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
-import bundleSize from 'rollup-plugin-bundle-size';
 import { terser } from 'rollup-plugin-terser';
 
 export default [
@@ -32,7 +31,6 @@ export default [
       typescript({ useTsconfigDeclarationDir: true }),
       commonjs(),
       resolve(),
-      bundleSize(),
     ],
   },
   {
@@ -53,7 +51,6 @@ export default [
       commonjs(),
       resolve(),
       terser(),
-      bundleSize(),
     ],
   }
 ];

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,49 +1,57 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import json from '@rollup/plugin-json';
-import sourceMaps from 'rollup-plugin-sourcemaps';
 import typescript from 'rollup-plugin-typescript2';
+import bundleSize from 'rollup-plugin-bundle-size';
+import { terser } from 'rollup-plugin-terser';
 
-const pkg = require('./package.json');
-
-const libraryName = 'zarr';
-
-const config = ({ input, output }) => {
-  return {
-    input,
-    output,
+export default [
+  {
+    input: {
+      zarr: 'src/zarr.ts',
+      core: 'src/zarr-core.ts',
+    },
+    output: [
+      {
+        dir: 'dist/',
+        format: 'es',
+        entryFileNames: '[name].mjs',
+        sourcemap: true,
+      },
+      {
+        dir: 'dist/',
+        format: 'cjs',
+        entryFileNames: '[name].cjs',
+        sourcemap: true,
+      },
+    ],
     watch: {
       include: 'src/**',
     },
     plugins: [
-      // Allow json resolution
-      json(),
-      // Compile TypeScript files
       typescript({ useTsconfigDeclarationDir: true }),
-      // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
       commonjs(),
-      // Allow node_modules resolution, so you can use 'external' to control
-      // which external modules to include in the bundle
-      // https://github.com/rollup/rollup-plugin-node-resolve#usage
       resolve(),
-      // Resolve source maps to the original source
-      sourceMaps(),
+    ],
+  },
+  {
+    input: 'src/zarr.ts',
+    output: {
+      file: 'dist/zarr.umd.js',
+      name: 'zarr',
+      format: 'umd',
+      sourcemap: true,
+      esModule: false,
+    },
+    plugins: [
+      typescript({
+        useTsconfigDeclarationDir: true,
+        // https://github.com/ezolenko/rollup-plugin-typescript2/issues/105
+        objectHashIgnoreUnknownHack: true,
+      }),
+      commonjs(),
+      resolve(),
+      terser(),
+      bundleSize(),
     ],
   }
-}
-
-export default [
-  config({
-    input: `src/${libraryName}.ts`,
-    output: [
-      { file: pkg.main, name: libraryName, format: 'umd', sourcemap: true },
-      { file: pkg.module, format: 'es', sourcemap: true },
-    ],
-  }),
-  config({
-    input: "src/zarr-core.ts",
-    output: {
-      file: pkg.exports['./core'], format: 'es', sourcemap: true
-    }
-  })
 ];

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -10,20 +10,12 @@ export default [
       zarr: 'src/zarr.ts',
       core: 'src/zarr-core.ts',
     },
-    output: [
-      {
-        dir: 'dist/',
-        format: 'es',
-        entryFileNames: '[name].mjs',
-        sourcemap: true,
-      },
-      {
-        dir: 'dist/',
-        format: 'cjs',
-        entryFileNames: '[name].cjs',
-        sourcemap: true,
-      },
-    ],
+    output: {
+      dir: 'dist/',
+      format: 'es',
+      entryFileNames: '[name].mjs',
+      sourcemap: true,
+    },
     watch: {
       include: 'src/**',
     },
@@ -31,6 +23,16 @@ export default [
       typescript({ useTsconfigDeclarationDir: true }),
       commonjs(),
       resolve(),
+    ],
+  },
+  {
+    input: 'src/zarr.ts',
+    output: { file: 'dist/zarr.cjs', format: 'cjs', sourcemap: true },
+    plugins: [
+      typescript({ useTsconfigDeclarationDir: true }),
+      commonjs(),
+      resolve(),
+      bundleSize(),
     ],
   },
   {

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -26,7 +26,11 @@ export default [
   },
   {
     input: 'src/zarr.ts',
-    output: { file: 'dist/zarr.cjs', format: 'cjs', sourcemap: true },
+    output: {
+      file: 'dist/zarr.cjs',
+      format: 'cjs',
+      sourcemap: true
+    },
     plugins: [
       typescript({ useTsconfigDeclarationDir: true }),
       commonjs(),

--- a/src/compression/registry.ts
+++ b/src/compression/registry.ts
@@ -1,10 +1,8 @@
-import { Codec, CompressorConfig } from 'numcodecs';
+import type { Codec, CompressorConfig } from 'numcodecs';
 
-type CodecConstructor = { fromConfig(config: Options & CompressorConfig): Codec };
-type CodecImporter = () => CodecConstructor | Promise<CodecConstructor>;
-
-const registry: Map<string, CodecImporter> = new Map();
-
+// TODO: This interface is tied to compressors in numcodecs..
+// might be better to just use 'any' or have numcodecs export complete 
+// (optional) config? 
 interface Options {
   level?: number;
   cname?: string;
@@ -12,6 +10,11 @@ interface Options {
   clevel?: number;
   shuffle?: number;
 }
+
+type CodecConstructor = { fromConfig(config: Options & CompressorConfig): Codec };
+type CodecImporter = () => CodecConstructor | Promise<CodecConstructor>;
+
+const registry: Map<string, CodecImporter> = new Map();
 
 export function addCodec(id: string, importFn: CodecImporter) {
   registry.set(id, importFn);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -229,11 +229,7 @@ export class ZarrArray {
     this.cacheMetadata = cacheMetadata;
     this.cacheAttrs = cacheAttrs;
     this.meta = metadata;
-    if (this.meta.compressor !== null) {
-      this.compressor = getCodec(this.meta.compressor);
-    } else {
-      this.compressor = null;
-    }
+    this.compressor = null;
 
 
     const attrKey = this.keyPrefix + ATTRS_META_KEY;
@@ -256,9 +252,12 @@ export class ZarrArray {
     }
   }
 
-  public get(selection?: undefined | Slice | ":" | "..." | null | (Slice | null | ":" | "...")[], opts?: GetOptions): Promise<NestedArray<TypedArray> | number>;
-  public get(selection?: ArraySelection, opts?: GetOptions): Promise<NestedArray<TypedArray> | number>;
-  public get(selection: ArraySelection = null, opts: GetOptions = {}): Promise<NestedArray<TypedArray> | number> {
+  public async get(selection?: undefined | Slice | ":" | "..." | null | (Slice | null | ":" | "...")[], opts?: GetOptions): Promise<NestedArray<TypedArray> | number>;
+  public async get(selection?: ArraySelection, opts?: GetOptions): Promise<NestedArray<TypedArray> | number>;
+  public async get(selection: ArraySelection = null, opts: GetOptions = {}): Promise<NestedArray<TypedArray> | number> {
+    if (this.meta.compressor !== null) {
+      this.compressor = await getCodec(this.meta.compressor);
+    }
     return this.getBasicSelection(selection, false, opts);
   }
 
@@ -507,6 +506,9 @@ export class ZarrArray {
   }
 
   public async set(selection: ArraySelection = null, value: any, opts: SetOptions = {}) {
+    if (this.meta.compressor !== null) {
+      this.compressor = await getCodec(this.meta.compressor);
+    }
     await this.setBasicSelection(selection, value, opts);
   }
 

--- a/src/zarr-core.ts
+++ b/src/zarr-core.ts
@@ -1,0 +1,18 @@
+export { addCodec, getCodec } from "./compression/registry";
+export { createProxy } from "./mutableMapping";
+export * from "./creation";
+export * from "./errors";
+export * from "./hierarchy";
+
+// export * from "./types";
+
+export { ZarrArray } from "./core";
+export { slice, sliceIndices } from "./core/slice";
+// export * from "./core/types";
+
+export { NestedArray, rangeTypedArray } from "./nestedArray";
+export * from "./nestedArray/types";
+
+export * from "./storage/memoryStore";
+export * from "./storage/objectStore";
+export * from "./storage/httpStore";

--- a/src/zarr.ts
+++ b/src/zarr.ts
@@ -1,17 +1,8 @@
-export { createProxy } from "./mutableMapping";
-export * from "./creation";
-export * from "./errors";
-export * from "./hierarchy";
+import { Zlib, GZip, Blosc } from 'numcodecs';
+import { addCodec } from './zarr-core';
 
-// export * from "./types";
+addCodec(Zlib.codecId, () => Zlib);
+addCodec(GZip.codecId, () => GZip);
+addCodec(Blosc.codecId, () => Blosc);
 
-export { ZarrArray } from "./core";
-export { slice, sliceIndices } from "./core/slice";
-// export * from "./core/types";
-
-export { NestedArray, rangeTypedArray } from "./nestedArray";
-export * from "./nestedArray/types";
-
-export * from "./storage/memoryStore";
-export * from "./storage/objectStore";
-export * from "./storage/httpStore";
+export * from './zarr-core';

--- a/test/compression/compression.test.ts
+++ b/test/compression/compression.test.ts
@@ -4,6 +4,13 @@ import { HTTPStore } from "../../src/storage/httpStore";
 import { openArray } from "../../src/creation";
 import { NestedArray } from "../../src/nestedArray";
 
+import { Zlib, GZip, Blosc } from 'numcodecs';
+import { addCodec } from '../../src/compression/registry';
+
+addCodec(Zlib.codecId, () => Zlib);
+addCodec(GZip.codecId, () => GZip);
+addCodec(Blosc.codecId, () => Blosc);
+
 describe("Test MemoryStore", () => {
     const hStore = new HTTPStore("http://localhost:7357/");
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "downlevelIteration": true,
-    "target": "es6",
-    "module": "es2015",
+    "target": "ESNext",
+    "module": "ESNext",
     "lib": [
       "es2015",
       "es2016",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "downlevelIteration": true,
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "es6",
+    "module": "es2015",
     "lib": [
       "es2015",
       "es2016",


### PR DESCRIPTION
I've been experimenting with some ideas to enable a dynamic codec registry. The idea here is to export a "batteries-included" version of `zarr`, which is one large bundle and easy to use, and a `zarr-core` module which includes an empty registry that can be customized.

Some feedback on how/what to export at the top level of each bundled export would be useful. In the end I'd like to see the most minimal change to enable custom behavior of loading codecs.

```
165k zarr-core.es6.js
829k zarr.es6.js
```
