### PR TITLE
Add getOptions to `getRawChunk`

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -14,6 +14,7 @@ import { TypedArray, DTYPE_TYPEDARRAY_MAPPING } from '../nestedArray/types';
 import { ValueError, PermissionError, KeyError, BoundsCheckError } from '../errors';
 import { getCodec } from "../compression/registry";
 
+
 import type { Codec } from 'numcodecs';
 import PQueue from 'p-queue';
 
@@ -31,6 +32,10 @@ export interface SetOptions {
     progress: number;
     queueSize: number;
   }) => void;
+}
+
+export interface GetRawChunkOptions<O> {
+  storeOptions: O,
 }
 
 export class ZarrArray {
@@ -424,7 +429,7 @@ export class ZarrArray {
     }
   }
 
-  public async getRawChunk(chunkCoords: number[]): Promise<RawArray> {
+  public async getRawChunk<O>(chunkCoords: number[], opts?: GetRawChunkOptions<O>): Promise<RawArray> {
     if (chunkCoords.length !== this.shape.length) {
       throw new Error(`Chunk coordinates ${chunkCoords.join(".")} do not correspond to shape ${this.shape}.`);
     }
@@ -441,7 +446,7 @@ export class ZarrArray {
       }
     }
     const cKey = this.chunkKey(chunkCoords);
-    const cdata = this.chunkStore.getItem(cKey);
+    const cdata = this.chunkStore.getItem(cKey, opts?.storeOptions)
     const buffer = await this.decodeChunk(await cdata);
     const outShape = this.chunks.filter(d => d !== 1); // squeeze chunk dim if 1
     return new RawArray(buffer, outShape, this.dtype);

--- a/src/mutableMapping.ts
+++ b/src/mutableMapping.ts
@@ -1,8 +1,8 @@
 /**
  * Closely resembles the functions on the MutableMapping type in Python.
  */
-export interface MutableMapping<T> {
-    getItem(item: string): T;
+export interface MutableMapping<T, O=any> {
+    getItem(item: string, opts?: O): T;
     setItem(item: string, value: T): boolean;
     deleteItem(item: string): boolean;
     containsItem(item: string): boolean;
@@ -15,8 +15,8 @@ export interface MutableMapping<T> {
 /**
  * Closely resembles the functions on the MutableMapping type in Python.
  */
-export interface AsyncMutableMapping<T> {
-    getItem(item: string): Promise<T>;
+export interface AsyncMutableMapping<T, O=any> {
+    getItem(item: string, opts?: O): Promise<T>;
     setItem(item: string, value: T): Promise<boolean>;
     deleteItem(item: string): Promise<boolean>;
     containsItem(item: string): Promise<boolean>;

--- a/src/storage/httpStore.ts
+++ b/src/storage/httpStore.ts
@@ -36,9 +36,9 @@ export class HTTPStore implements AsyncStore<ArrayBuffer> {
         throw new Error('Method not implemented.');
     }
 
-    async getItem(item: string) {
+    async getItem(item: string, opts?: RequestInit) {
         const url = joinUrlParts(this.url, item);
-        const value = await fetch(url, this.fetchOptions);
+        const value = await fetch(url, { ...this.fetchOptions, ...opts });
 
         if (value.status === 404) {
             // Item is not found

--- a/src/storage/memoryStore.ts
+++ b/src/storage/memoryStore.ts
@@ -73,8 +73,7 @@ export class MemoryStore<T extends ValidStoreType> implements SyncStore<T> {
         // TODO: more sane implementation
         try {
             return this.getItem(item) !== undefined;
-        }
-        catch {
+        } catch (e) {
             return false;
         }
     }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -20,7 +20,7 @@ export type Store = SyncStore<ValidStoreType> | AsyncStore<ValidStoreType>;
  * Store classes may also optionally implement a `rename` method (rename all members under a given
  * path) and a `getSize` method (return the size in bytes of a given value).
  */
-export interface SyncStore<T extends ValidStoreType> extends MutableMapping<T> {
+export interface SyncStore<T extends ValidStoreType, O=any> extends MutableMapping<T, O> {
     listDir?: (path?: string) => string[];
     rmDir?: (path?: string) => boolean;
     getSize?: (path?: string) => number;
@@ -31,7 +31,7 @@ export interface SyncStore<T extends ValidStoreType> extends MutableMapping<T> {
 /**
  * Async version of Store
  */
-export interface AsyncStore<T extends ValidStoreType> extends AsyncMutableMapping<T> {
+export interface AsyncStore<T extends ValidStoreType, O=any> extends AsyncMutableMapping<T, O> {
     listDir?: (path?: string) => Promise<string[]>;
     rmDir?: (path?: string) => Promise<boolean>;
     getSize?: (path?: string) => Promise<number>;


### PR DESCRIPTION
## Description 

 This PR adds a generic `opts` parameter to the `store.getItem` interface, allowing more granular control over a request for data when calling `store.getItem`. 

## Usage

```javascript
import { openArray } from 'zarr';
const a = await openArray({ store: 'https://localhost:8080 });
const res = await a.getRawChunk([0,0,0], { storeOptions: { signal } }); // storeOptions are optional and generic over the underlying store
```

## Motivation

In Viv, we use zarr.js to fetch data tiles via requests scheduled by a deck.gl, ultimately mapping a request for tile `x`, `y` `z` to `ZarrArray.getRawChunk`. These requests are made concurrently and independent of each other. Each request for data triggered by deck.gl also creates an `AbortSignal` that is intended to be forwarded to the underling `fetch` method so that a request can be cancelled (https://github.com/visgl/deck.gl/blob/master/docs/api-reference/geo-layers/tile-layer.md#gettiledata-function-optional).

I'd hoped this was something we could tackle outside of making a PR to zarr.js (we have made several attempts), but I have failed to come up with something that doesn't require 1.) Implementing a custom `HTTPStore` (with additional props in getItem) and re-writing many of the internals of `getRawChunk`: https://github.com/hms-dbmi/viv/blob/ae46523875a3db35e8e3589fc3b15f472033c85f/src/loaders/zarrLoader.js#L68-L104, or 2.) trying to pass around a `signal` on a custom store https://github.com/hms-dbmi/viv/pull/358#discussion_r562125600


Perhaps there is something I am missing, but I'm fairly satisfied with the solution put forward in this PR. Cheers!
