### PR TITLE
Remove 404s for openArray & openGroup

### DIFF
--- a/src/creation.ts
+++ b/src/creation.ts
@@ -151,9 +151,10 @@ export async function openArray(
     path = normalizeStoragePath(path);
 
     if (mode === "r" || mode === "r+") {
-        if (await containsGroup(store, path)) {
-            throw new ContainsGroupError(path);
-        } else if (!await containsArray(store, path)) {
+        if (!await containsArray(store, path)) {
+            if (await containsGroup(store, path)) {
+                throw new ContainsGroupError(path);
+            }
             throw new ArrayNotFoundError(path);
         }
     } else if (mode === "w") {
@@ -164,9 +165,10 @@ export async function openArray(
         await initArray(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters);
 
     } else if (mode === "a") {
-        if (await containsGroup(store, path)) {
-            throw new ContainsGroupError(path);
-        } else if (!await containsArray(store, path)) {
+        if (!await containsArray(store, path)) {
+            if (await containsGroup(store, path)) {
+                throw new ContainsGroupError(path);
+            }
             if (shape === undefined) {
                 throw new ValueError("Shape can not be undefined when creating a new array");
             }

--- a/src/hierarchy.ts
+++ b/src/hierarchy.ts
@@ -288,21 +288,21 @@ export async function openGroup(store?: Store | string, path: string | null = nu
     path = normalizeStoragePath(path);
 
     if (mode === "r" || mode === "r+") {
-        if (await containsArray(store, path)) {
-            throw new ContainsArrayError(path);
-        } else if (!await containsGroup(store, path)) {
+        if (!await containsGroup(store, path)) {
+            if (await containsArray(store, path)) {
+                throw new ContainsArrayError(path);
+            }
             throw new GroupNotFoundError(path);
         }
     } else if (mode === "w") {
         await initGroup(store, path, chunkStore, true);
     } else if (mode === "a") {
-
-        if (await containsArray(store, path)) {
-            throw new ContainsArrayError(path);
-        } else if (!await containsGroup(store, path)) {
+        if (!await containsGroup(store, path)) {
+            if (await containsArray(store, path)) {
+                throw new ContainsArrayError(path);
+            }
             await initGroup(store, path, chunkStore);
         }
-
     } else if (mode === "w-" || (mode as any) === "x") {
         if (await containsArray(store, path)) {
             throw new ContainsArrayError(path);

--- a/src/hierarchy.ts
+++ b/src/hierarchy.ts
@@ -74,17 +74,14 @@ export class Group implements AsyncMutableMapping<Group | ZarrArray> {
 
     private static async loadMetadataForConstructor(store: Store, path: null | string) {
         path = normalizeStoragePath(path);
-
-        if (await containsArray(store, path)) {
-            throw new ContainsArrayError(path);
-        }
-
         const keyPrefix = pathToPrefix(path);
         try {
             const metaStoreValue = await store.getItem(keyPrefix + GROUP_META_KEY);
             return parseMetadata(metaStoreValue);
-        }
-        catch (error) {
+        } catch (error) {
+            if (await containsArray(store, path)) {
+                throw new ContainsArrayError(path);
+            }
             throw new GroupNotFoundError(path);
         }
     }
@@ -220,7 +217,7 @@ export class Group implements AsyncMutableMapping<Group | ZarrArray> {
     async getItem(item: string) {
         const path = this.itemPath(item);
         if (await containsArray(this.store, path)) {
-            return ZarrArray.create(this.store, this.path, this.readOnly, this.chunkStore, undefined, this.attrs.cache);
+            return ZarrArray.create(this.store, path, this.readOnly, this.chunkStore, undefined, this.attrs.cache);
         } else if (await containsGroup(this.store, path)) {
             return Group.create(this.store, path, this.readOnly, this._chunkStore, this.attrs.cache);
         }

--- a/src/names.ts
+++ b/src/names.ts
@@ -1,3 +1,3 @@
 export const ARRAY_META_KEY = ".zarray";
 export const GROUP_META_KEY = ".zgroup";
-export const ATTRS_META_KEY = ".zattributes";
+export const ATTRS_META_KEY = ".zattrs";


### PR DESCRIPTION
This PR rearranges the conditionals in `openArray` and `openGroup` when `mode` is `a`, `r`, or `r+`, so that a request to check the alternate node exists in only made if the desired node isn't present. This should remove a bunch of annoying 404s in the console when calling `openArray` on an `HTTPStore`. 

 I'm going to also make a PR to zarr-python for these changes as this control flow should reduce the number of store operations when you are trying to read from the "correct" correct node.