### PR TITLE
v0.4

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,7 +74,7 @@ import * as zarr from "https://cdn.skypack.dev/zarr";
 
 ```html
 <!-- Import as UMD in HTML -->
-<script src="https://unpkg.com/zarr/dist/zarr.umd.js"></script>
+<script src="https://unpkg.com/zarr/zarr.umd.js"></script>
 ```
 **Example**
 ```html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zarr",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zarr",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Javascript implementation of Zarr",
   "keywords": [
     "ndarray",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "zarr.umd.js",
     "zarr.umd.js.map"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./zarr.mjs"
+  ],
   "main": "zarr.cjs",
   "module": "zarr.mjs",
   "umd:main": "zarr.umd.js",


### PR DESCRIPTION
Just published! Bundles are substantially smaller, thanks @gzuidhof !

```javascript
// index.js
import { openArray } from 'zarr/core';
console.log(openArray);

// rollup.config.js
import resolve from '@rollup/plugin-node-resolve';
import bsize from 'rollup-plugin-bundle-size';
import {terser} from 'rollup-plugin-terser';

export default {
  input: 'index.js',
  output: { file: 'bundle.js', format: 'esm' },
  plugins: [ resolve(), terser(), bsize() ]
}
```

```bash
$ rollup -c 
# Created bundle bundle.js: 35.17 kB -> 10.59kB (gzip)
```

importing from top-level (`zarr`):

```bash
$ rollup -c 
# Created bundle bundle.js: 519.83 kB -> 184.17 kB (gzip)
```

