### PR TITLE
Add ZarrError interface to allow custom errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zarr",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zarr",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Javascript implementation of Zarr",
   "keywords": [
     "ndarray",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,3 @@
-// Custom error messages, note we have to patch the prototype of the
-// errors to fix `instanceof` calls, see:
-// https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
 export interface ZarrError {
     __zarr__: string;
 }
@@ -13,6 +10,9 @@ export function isKeyError(o: unknown) {
     return isZarrError(o) && o.__zarr__ === 'KeyError';
 }
 
+// Custom error messages, note we have to patch the prototype of the
+// errors to fix `instanceof` calls, see:
+// https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
 export class ContainsArrayError extends Error implements ZarrError {
     __zarr__ = 'ContainsArrayError';
     constructor(path: string) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,94 +1,118 @@
 // Custom error messages, note we have to patch the prototype of the
 // errors to fix `instanceof` calls, see:
 // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+export interface ZarrError {
+    __zarr__: string;
+}
 
-export class ContainsArrayError extends Error {
+function isZarrError(err: unknown): err is ZarrError {
+    return typeof err === 'object' && err !== null && '__zarr__' in err;
+}
+
+export function isKeyError(o: unknown) {
+    return isZarrError(o) && o.__zarr__ === 'KeyError';
+}
+
+export class ContainsArrayError extends Error implements ZarrError {
+    __zarr__ = 'ContainsArrayError';
     constructor(path: string) {
         super(`path ${path} contains an array`);
         Object.setPrototypeOf(this, ContainsArrayError.prototype);
     }
 }
 
-export class ContainsGroupError extends Error {
+export class ContainsGroupError extends Error implements ZarrError {
+    __zarr__ = 'ContainsGroupError';
     constructor(path: string) {
         super(`path ${path} contains a group`);
         Object.setPrototypeOf(this, ContainsGroupError.prototype);
     }
 }
 
-export class ArrayNotFoundError extends Error {
+export class ArrayNotFoundError extends Error implements ZarrError {
+    __zarr__ = 'ArrayNotFoundError';
     constructor(path: string) {
         super(`array not found at path ${path}`);
         Object.setPrototypeOf(this, ArrayNotFoundError.prototype);
     }
 }
 
-export class GroupNotFoundError extends Error {
+export class GroupNotFoundError extends Error implements ZarrError {
+    __zarr__ = 'GroupNotFoundError';
     constructor(path: string) {
         super(`ground not found at path ${path}`);
         Object.setPrototypeOf(this, GroupNotFoundError.prototype);
     }
 }
 
-export class PathNotFoundError extends Error {
+export class PathNotFoundError extends Error implements ZarrError {
+    __zarr__ = 'PathNotFoundError';
     constructor(path: string) {
         super(`nothing not found at path ${path}`);
         Object.setPrototypeOf(this, PathNotFoundError.prototype);
     }
 }
 
-export class PermissionError extends Error {
+export class PermissionError extends Error implements ZarrError {
+    __zarr__ = 'PermissionError';
     constructor(message: string) {
         super(message);
         Object.setPrototypeOf(this, PermissionError.prototype);
     }
 }
 
-export class KeyError extends Error {
+export class KeyError extends Error implements ZarrError {
+    __zarr__ = 'KeyError';
     constructor(key: string) {
         super(`key ${key} not present`);
         Object.setPrototypeOf(this, KeyError.prototype);
     }
 }
 
-export class TooManyIndicesError extends RangeError {
+export class TooManyIndicesError extends RangeError implements ZarrError {
+    __zarr__ = 'TooManyIndicesError';
     constructor(selection: any[], shape: number[]) {
         super(`too many indices for array; expected ${shape.length}, got ${selection.length}`);
         Object.setPrototypeOf(this, TooManyIndicesError.prototype);
     }
 }
 
-export class BoundsCheckError extends RangeError {
+export class BoundsCheckError extends RangeError implements ZarrError {
+    __zarr__ = 'BoundsCheckError';
     constructor(message: string) {
         super(message);
         Object.setPrototypeOf(this, BoundsCheckError.prototype);
     }
 }
 
-export class InvalidSliceError extends RangeError {
+export class InvalidSliceError extends RangeError implements ZarrError {
+    __zarr__ = 'InvalidSliceError';
     constructor(from: any, to: any, stepSize: any, reason: any) {
         super(`slice arguments slice(${from}, ${to}, ${stepSize}) invalid: ${reason}`);
         Object.setPrototypeOf(this, InvalidSliceError.prototype);
     }
 }
 
-export class NegativeStepError extends Error {
+export class NegativeStepError extends Error implements ZarrError {
+    __zarr__ = 'NegativeStepError';
     constructor() {
         super(`Negative step size is not supported when indexing.`);
         Object.setPrototypeOf(this, NegativeStepError.prototype);
     }
 }
 
-export class ValueError extends Error {
+export class ValueError extends Error implements ZarrError {
+    __zarr__ = 'ValueError';
     constructor(message: string) {
         super(message);
         Object.setPrototypeOf(this, ValueError.prototype);
     }
 }
 
-export class HTTPError extends Error {
+export class HTTPError extends Error implements ZarrError {
+    __zarr__ = 'HTTPError';
     constructor(code: string) {
-      super(code);
-      Object.setPrototypeOf(this, HTTPError.prototype);
+        super(code);
+        Object.setPrototypeOf(this, HTTPError.prototype);
     }
-  }
+}


### PR DESCRIPTION
Related to #69. This PR adds a `ZarrError` interface which just requires a `__zarr__` key on an object so that third party libraries can implement custom stores.