### PR TITLE
Better error message for unsupported dtypes

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -10,7 +10,7 @@ import { ArraySelection, DimensionSelection, Indexer, Slice, ChunkProjection } f
 import { BasicIndexer, isContiguousSelection, normalizeIntegerSelection } from './indexing';
 import { NestedArray } from "../nestedArray";
 import { RawArray } from "../rawArray";
-import { TypedArray, getTypedArray } from '../nestedArray/types';
+import { TypedArray, getTypedArrayCtr } from '../nestedArray/types';
 import { ValueError, PermissionError, BoundsCheckError, ContainsGroupError, isKeyError } from '../errors';
 import { getCodec } from "../compression/registry";
 
@@ -466,7 +466,7 @@ export class ZarrArray {
   }
 
   private toTypedArray(buffer: Buffer | ArrayBuffer) {
-    return new (getTypedArray(this.dtype))(buffer);
+    return new (getTypedArrayCtr(this.dtype))(buffer);
   }
 
   private toNestedArray<T extends TypedArray>(data: ValidStoreType) {
@@ -504,7 +504,7 @@ export class ZarrArray {
     } catch (error) {
       if (isKeyError(error)) {
         // fill with scalar if item doesn't exist
-        const data = new (getTypedArray(this.dtype))(outSize);
+        const data = new (getTypedArrayCtr(this.dtype))(outSize);
         return new RawArray(data.fill(this.fillValue as number), outShape);
       } else {
         // Different type of error - rethrow
@@ -619,7 +619,7 @@ export class ZarrArray {
 
     let chunk: null | TypedArray = null;
 
-    const dtypeConstr = getTypedArray(this.dtype);
+    const dtypeConstr = getTypedArrayCtr(this.dtype);
     const chunkSize = this.chunkSize;
 
     if (isTotalSlice(chunkSelection, this.chunks)) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -10,7 +10,7 @@ import { ArraySelection, DimensionSelection, Indexer, Slice, ChunkProjection } f
 import { BasicIndexer, isContiguousSelection, normalizeIntegerSelection } from './indexing';
 import { NestedArray } from "../nestedArray";
 import { RawArray } from "../rawArray";
-import { TypedArray, DTYPE_TYPEDARRAY_MAPPING } from '../nestedArray/types';
+import { TypedArray, getTypedArray } from '../nestedArray/types';
 import { ValueError, PermissionError, BoundsCheckError, ContainsGroupError, isKeyError } from '../errors';
 import { getCodec } from "../compression/registry";
 
@@ -466,7 +466,7 @@ export class ZarrArray {
   }
 
   private toTypedArray(buffer: Buffer | ArrayBuffer) {
-    return new DTYPE_TYPEDARRAY_MAPPING[this.dtype](buffer);
+    return new (getTypedArray(this.dtype))(buffer);
   }
 
   private toNestedArray<T extends TypedArray>(data: ValidStoreType) {
@@ -504,7 +504,7 @@ export class ZarrArray {
     } catch (error) {
       if (isKeyError(error)) {
         // fill with scalar if item doesn't exist
-        const data = new DTYPE_TYPEDARRAY_MAPPING[this.dtype](outSize);
+        const data = new (getTypedArray(this.dtype))(outSize);
         return new RawArray(data.fill(this.fillValue as number), outShape);
       } else {
         // Different type of error - rethrow
@@ -619,7 +619,7 @@ export class ZarrArray {
 
     let chunk: null | TypedArray = null;
 
-    const dtypeConstr = DTYPE_TYPEDARRAY_MAPPING[this.dtype];
+    const dtypeConstr = getTypedArray(this.dtype);
     const chunkSize = this.chunkSize;
 
     if (isTotalSlice(chunkSelection, this.chunks)) {

--- a/src/nestedArray/index.ts
+++ b/src/nestedArray/index.ts
@@ -1,5 +1,5 @@
 import { DtypeString } from '../types';
-import { NestedArrayData, TypedArray, TypedArrayConstructor, DTYPE_TYPEDARRAY_MAPPING, getTypedArrayDtypeString } from './types';
+import { NestedArrayData, TypedArray, TypedArrayConstructor, getTypedArray, getTypedArrayDtypeString } from './types';
 import { ArraySelection, Slice } from '../core/types';
 import { slice } from '../core/slice';
 import { ValueError } from '../errors';
@@ -40,7 +40,7 @@ export class NestedArray<T extends TypedArray> {
 
         // Zero dimension array.. they are a bit weirdly represented now, they will only ever occur internally
         if (this.shape.length === 0) {
-            this.data = new DTYPE_TYPEDARRAY_MAPPING[dtype](1);
+            this.data = new (getTypedArray(dtype))(1);
         }
         else if (
             // tslint:disable-next-line: strict-type-predicates
@@ -60,7 +60,7 @@ export class NestedArray<T extends TypedArray> {
             if (numShapeElements !== numDataElements) {
                 throw new Error(`Buffer has ${numDataElements} of dtype ${dtype}, shape is too large or small ${shape} (flat=${numShapeElements})`);
             }
-            const typeConstructor: TypedArrayConstructor<TypedArray> = DTYPE_TYPEDARRAY_MAPPING[dtype];
+            const typeConstructor: TypedArrayConstructor<TypedArray> = getTypedArray(dtype);
             this.data = createNestedArray((data as ArrayBuffer), typeConstructor, shape);
         } else {
             this.data = data;
@@ -98,14 +98,14 @@ export class NestedArray<T extends TypedArray> {
         if (this.shape.length === 1) {
             return this.data as T;
         }
-        return flattenNestedArray(this.data, this.shape, DTYPE_TYPEDARRAY_MAPPING[this.dtype]) as T;
+        return flattenNestedArray(this.data, this.shape, getTypedArray(this.dtype)) as T;
     }
 
     /**
      * Currently only supports a single integer as the size, TODO: support start, stop, step.
      */
     public static arange(size: number, dtype: DtypeString = "<i4"): NestedArray<TypedArray> {
-        const constr = DTYPE_TYPEDARRAY_MAPPING[dtype];
+        const constr = getTypedArray(dtype);
         const data = rangeTypedArray([size], constr);
         return new NestedArray(data, [size], dtype);
     }

--- a/src/nestedArray/index.ts
+++ b/src/nestedArray/index.ts
@@ -1,5 +1,5 @@
 import { DtypeString } from '../types';
-import { NestedArrayData, TypedArray, TypedArrayConstructor, getTypedArray, getTypedArrayDtypeString } from './types';
+import { NestedArrayData, TypedArray, TypedArrayConstructor, getTypedArrayCtr, getTypedArrayDtypeString } from './types';
 import { ArraySelection, Slice } from '../core/types';
 import { slice } from '../core/slice';
 import { ValueError } from '../errors';
@@ -40,7 +40,7 @@ export class NestedArray<T extends TypedArray> {
 
         // Zero dimension array.. they are a bit weirdly represented now, they will only ever occur internally
         if (this.shape.length === 0) {
-            this.data = new (getTypedArray(dtype))(1);
+            this.data = new (getTypedArrayCtr(dtype))(1);
         }
         else if (
             // tslint:disable-next-line: strict-type-predicates
@@ -60,7 +60,7 @@ export class NestedArray<T extends TypedArray> {
             if (numShapeElements !== numDataElements) {
                 throw new Error(`Buffer has ${numDataElements} of dtype ${dtype}, shape is too large or small ${shape} (flat=${numShapeElements})`);
             }
-            const typeConstructor: TypedArrayConstructor<TypedArray> = getTypedArray(dtype);
+            const typeConstructor: TypedArrayConstructor<TypedArray> = getTypedArrayCtr(dtype);
             this.data = createNestedArray((data as ArrayBuffer), typeConstructor, shape);
         } else {
             this.data = data;
@@ -98,14 +98,14 @@ export class NestedArray<T extends TypedArray> {
         if (this.shape.length === 1) {
             return this.data as T;
         }
-        return flattenNestedArray(this.data, this.shape, getTypedArray(this.dtype)) as T;
+        return flattenNestedArray(this.data, this.shape, getTypedArrayCtr(this.dtype)) as T;
     }
 
     /**
      * Currently only supports a single integer as the size, TODO: support start, stop, step.
      */
     public static arange(size: number, dtype: DtypeString = "<i4"): NestedArray<TypedArray> {
-        const constr = getTypedArray(dtype);
+        const constr = getTypedArrayCtr(dtype);
         const data = rangeTypedArray([size], constr);
         return new NestedArray(data, [size], dtype);
     }

--- a/src/nestedArray/types.ts
+++ b/src/nestedArray/types.ts
@@ -57,7 +57,7 @@ const DTYPE_TYPEDARRAY_MAPPING: { [A in DtypeString]: TypedArrayConstructor<Type
 };
 
 
-export function getTypedArray(dtype: DtypeString) {
+export function getTypedArrayCtr(dtype: DtypeString) {
   const ctr = DTYPE_TYPEDARRAY_MAPPING[dtype];
   if (!ctr) {
     throw Error(`Dtype not recognized or not supported in zarr.js, got ${dtype}.`);

--- a/src/nestedArray/types.ts
+++ b/src/nestedArray/types.ts
@@ -20,24 +20,16 @@ export type TypedArray =
   | Float32Array
   | Float64Array;
 
-// ArrayLike<any> & {
-//     BYTES_PER_ELEMENT: number;
-//     set(array: ArrayLike<number>, offset?: number): void;
-//     slice(start?: number, end?: number): TypedArray;
-//     subarray(start?: number, end?: number): TypedArray;
-//     buffer: Buffer | ArrayBuffer;
-//     constructor: TypedArrayConstructor<TypedArray>;
-// };
-export type TypedArrayConstructor<TypedArray> = {
-  new(): TypedArray;
+export type TypedArrayConstructor<T extends TypedArray> = {
+  new(): T;
   // tslint:disable-next-line: unified-signatures
-  new(size: number): TypedArray;
+  new(size: number): T;
   // tslint:disable-next-line: unified-signatures
-  new(buffer: ArrayBuffer): TypedArray;
+  new(buffer: ArrayBuffer): T;
   BYTES_PER_ELEMENT: number;
 };
 
-export const DTYPE_TYPEDARRAY_MAPPING: { [A in DtypeString]: TypedArrayConstructor<TypedArray> } = {
+const DTYPE_TYPEDARRAY_MAPPING: { [A in DtypeString]: TypedArrayConstructor<TypedArray> } = {
   '|b': Int8Array,
   '|B': Uint8Array,
   '|u1': Uint8Array,
@@ -63,6 +55,15 @@ export const DTYPE_TYPEDARRAY_MAPPING: { [A in DtypeString]: TypedArrayConstruct
   '>f4': Float32Array,
   '>f8': Float64Array
 };
+
+
+export function getTypedArray(dtype: DtypeString) {
+  const ctr = DTYPE_TYPEDARRAY_MAPPING[dtype];
+  if (!ctr) {
+    throw Error(`Dtype not recognized or not supported in zarr.js, got ${dtype}.`);
+  }
+  return ctr;
+}
 
 /*
  * Called by NestedArray and RawArray constructors only.

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -3,7 +3,7 @@ import { ArraySelection } from '../core/types';
 import { slice } from '../core/slice';
 import { ValueError } from '../errors';
 import { normalizeShape, IS_NODE, getStrides } from '../util';
-import { TypedArray, DTYPE_TYPEDARRAY_MAPPING, getTypedArrayDtypeString, TypedArrayConstructor } from '../nestedArray/types';
+import { TypedArray, getTypedArray, getTypedArrayDtypeString, TypedArrayConstructor } from '../nestedArray/types';
 import { setRawArrayFromChunkItem, setRawArrayToScalar, setRawArray } from './ops';
 
 export class RawArray {
@@ -46,7 +46,7 @@ export class RawArray {
 
         // Zero dimension array.. they are a bit weirdly represented now, they will only ever occur internally
         if (this.shape.length === 0) {
-            this.data = new DTYPE_TYPEDARRAY_MAPPING[dtype](1);
+            this.data = new (getTypedArray(dtype))(1);
         } else if (
             // tslint:disable-next-line: strict-type-predicates
             (IS_NODE && Buffer.isBuffer(data))
@@ -65,7 +65,7 @@ export class RawArray {
             if (numShapeElements !== numDataElements) {
                 throw new Error(`Buffer has ${numDataElements} of dtype ${dtype}, shape is too large or small ${shape} (flat=${numShapeElements})`);
             }
-            const typeConstructor: TypedArrayConstructor<TypedArray> = DTYPE_TYPEDARRAY_MAPPING[dtype];
+            const typeConstructor: TypedArrayConstructor<TypedArray> = getTypedArray(dtype);
             this.data = new typeConstructor(data as ArrayBuffer);
         } else {
             this.data = data;

--- a/src/rawArray/index.ts
+++ b/src/rawArray/index.ts
@@ -3,7 +3,7 @@ import { ArraySelection } from '../core/types';
 import { slice } from '../core/slice';
 import { ValueError } from '../errors';
 import { normalizeShape, IS_NODE, getStrides } from '../util';
-import { TypedArray, getTypedArray, getTypedArrayDtypeString, TypedArrayConstructor } from '../nestedArray/types';
+import { TypedArray, getTypedArrayCtr, getTypedArrayDtypeString, TypedArrayConstructor } from '../nestedArray/types';
 import { setRawArrayFromChunkItem, setRawArrayToScalar, setRawArray } from './ops';
 
 export class RawArray {
@@ -46,7 +46,7 @@ export class RawArray {
 
         // Zero dimension array.. they are a bit weirdly represented now, they will only ever occur internally
         if (this.shape.length === 0) {
-            this.data = new (getTypedArray(dtype))(1);
+            this.data = new (getTypedArrayCtr(dtype))(1);
         } else if (
             // tslint:disable-next-line: strict-type-predicates
             (IS_NODE && Buffer.isBuffer(data))
@@ -65,7 +65,7 @@ export class RawArray {
             if (numShapeElements !== numDataElements) {
                 throw new Error(`Buffer has ${numDataElements} of dtype ${dtype}, shape is too large or small ${shape} (flat=${numShapeElements})`);
             }
-            const typeConstructor: TypedArrayConstructor<TypedArray> = getTypedArray(dtype);
+            const typeConstructor: TypedArrayConstructor<TypedArray> = getTypedArrayCtr(dtype);
             this.data = new typeConstructor(data as ArrayBuffer);
         } else {
             this.data = data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type ZarrMetadataType = ZarrArrayMetadata | ZarrGroupMetadata;
-export type UserAttributes = object;
+export type UserAttributes = Record<string, any>;
 
 /**
  * A scalar value providing the default value to use for uninitialized portions of the array, or `null` if no fill_value is to be used.
@@ -84,11 +84,7 @@ export interface ZarrArrayMetadata {
   /**
    * A JSON object identifying the primary compression codec and providing configuration parameters, or null if no compressor is to be used. The object MUST contain an "id" key identifying the codec to be used.
    */
-  compressor:
-    | null
-    | ({
-        id: string;
-      } & any);
+  compressor: null | CompressorConfig & Record<string, any>;
 
   /**
    * A scalar value providing the default value to use for uninitialized portions of the array, or `null` if no fill_value is to be used.

--- a/test/core/zarrArray.test.ts
+++ b/test/core/zarrArray.test.ts
@@ -67,6 +67,13 @@ describe("ZarrArray Creation", () => {
         await expect(ZarrArray.create(occupiedStore)).rejects.toBeTruthy();
     });
 
+    it("errors for unsupported/invalid dtype", async () => {
+        const store = new ObjectStore<Buffer>();
+        await initArray(store, 100, 5, '<i8' as any);
+        const z = await ZarrArray.create(store);
+        await expect(z.get(null)).rejects.toBeTruthy();
+    });
+
 });
 
 
@@ -114,13 +121,13 @@ describe("ZarrArray Set with progress callback", () => {
 describe("ZarrArray Get with progress callback", () => {
     it("calls the callback the right amount of times with progress", async () => {
         const cb = jest.fn();
-        const z = await zeros([5, 100], {chunks: [1, 50]});
-        await z.get(null, {progressCallback: cb});
-        expect(cb.mock.calls.length).toBe(10+1);
-        expect(cb.mock.calls[0][0]).toEqual({progress: 0, queueSize: 10});
-        expect(cb.mock.calls[5][0]).toEqual({progress: 5, queueSize: 10});
-        expect(cb.mock.calls[10][0]).toEqual({progress: 10, queueSize: 10});
-    });  
+        const z = await zeros([5, 100], { chunks: [1, 50] });
+        await z.get(null, { progressCallback: cb });
+        expect(cb.mock.calls.length).toBe(10 + 1);
+        expect(cb.mock.calls[0][0]).toEqual({ progress: 0, queueSize: 10 });
+        expect(cb.mock.calls[5][0]).toEqual({ progress: 5, queueSize: 10 });
+        expect(cb.mock.calls[10][0]).toEqual({ progress: 10, queueSize: 10 });
+    });
 });
 
 function nestedArrayEquals(a: NestedArray<any> | number, b: NestedArray<any> | number) {


### PR DESCRIPTION
This PR adds better error messages when trying to access unsupported dtypes as mentioned in #85. 

Supporting `i8`/`u8` dtypes is a goal, but `BigInt`/`BigUint` typedarrays are only supported in some browsers, and accessing elements of these arrays returns `bigint` types (not `number`), which our current code isn't generic over.


```javascript
import { openArray } from 'zarr';

const z = await openArray({ store: 'https://localhost:8080' }); // dtype === '<i8'
await z.get(null);
// Error: Dtype not recognized or not supported in zarr.js, got <i8.
```