### PR TITLE
Support nested chunk storage

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -116,6 +116,13 @@ export class ZarrArray {
   }
 
   /**
+   *  Boolean. True if chunks are stored in a nested directory tree.
+   */
+  public get nested() {
+    return this.meta.nested;
+  }
+
+  /**
    *  A value used for uninitialized portions of the array.
    */
   public get fillValue(): FillType {
@@ -455,7 +462,8 @@ export class ZarrArray {
   }
 
   private chunkKey(chunkCoords: number[]) {
-    return this.keyPrefix + chunkCoords.join(".");
+    const delimiter = this.nested ? "/" : "."
+    return this.keyPrefix + chunkCoords.join(delimiter);
   }
 
   private ensureByteArray(chunkData: ValidStoreType): Uint8Array {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -462,7 +462,7 @@ export class ZarrArray {
   }
 
   private chunkKey(chunkCoords: number[]) {
-    const delimiter = this.nested ? "/" : "."
+    const delimiter = this.nested ? "/" : ".";
     return this.keyPrefix + chunkCoords.join(delimiter);
   }
 

--- a/src/creation.ts
+++ b/src/creation.ts
@@ -43,6 +43,7 @@ export type CreateArrayOptions = {
     cacheMetadata?: boolean;
     cacheAttrs?: boolean;
     readOnly?: boolean;
+    nested?: false;
 };
 
 /**
@@ -71,12 +72,12 @@ export type CreateArrayOptions = {
  * @param readOnly `true` if array should be protected against modification, defaults to `false`.
  */
 export async function create(
-    { shape, chunks = true, dtype = "<i4", compressor = null, fillValue = null, order = "C", store, overwrite = false, path, chunkStore, filters, cacheMetadata = true, cacheAttrs = true, readOnly = false }: CreateArrayOptions,
+    { shape, chunks = true, dtype = "<i4", compressor = null, fillValue = null, order = "C", store, overwrite = false, path, chunkStore, filters, cacheMetadata = true, cacheAttrs = true, readOnly = false, nested = false }: CreateArrayOptions,
 ): Promise<ZarrArray> {
 
     store = normalizeStoreArgument(store);
 
-    await initArray(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters);
+    await initArray(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters, nested);
     const z = await ZarrArray.create(store, path, readOnly, chunkStore, cacheMetadata, cacheAttrs);
 
     return z;
@@ -142,7 +143,7 @@ export async function array(data: Buffer | ArrayBuffer | NestedArray<TypedArray>
 }
 
 export async function openArray(
-    { shape, mode = "a", chunks = true, dtype = "<i4", compressor = null, fillValue = null, order = "C", store, overwrite = false, path = null, chunkStore, filters, cacheMetadata = true, cacheAttrs = true }: { shape?: number | number[]; mode?: PersistenceMode; chunks?: ChunksArgument; dtype?: DtypeString; compressor?: CompressorConfig | null; fillValue?: FillType; order?: Order; store?: Store; overwrite?: boolean; path?: string | null; chunkStore?: Store; filters?: Filter[]; cacheMetadata?: boolean; cacheAttrs?: boolean } = {},
+    { shape, mode = "a", chunks = true, dtype = "<i4", compressor = null, fillValue = null, order = "C", store, overwrite = false, path = null, chunkStore, filters, cacheMetadata = true, cacheAttrs = true, nested = false }: { shape?: number | number[]; mode?: PersistenceMode; chunks?: ChunksArgument; dtype?: DtypeString; compressor?: CompressorConfig | null; fillValue?: FillType; order?: Order; store?: Store; overwrite?: boolean; path?: string | null; chunkStore?: Store; filters?: Filter[]; cacheMetadata?: boolean; cacheAttrs?: boolean; nested?: boolean } = {},
 ) {
     store = normalizeStoreArgument(store);
     if (chunkStore === undefined) {
@@ -162,7 +163,7 @@ export async function openArray(
         if (shape === undefined) {
             throw new ValueError("Shape can not be undefined when creating a new array");
         }
-        await initArray(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters);
+        await initArray(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters, nested);
 
     } else if (mode === "a") {
         if (!await containsArray(store, path)) {
@@ -172,7 +173,7 @@ export async function openArray(
             if (shape === undefined) {
                 throw new ValueError("Shape can not be undefined when creating a new array");
             }
-            await initArray(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters);
+            await initArray(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters, nested);
         }
     } else if (mode === "w-" || (mode as any) === "x") {
         if (await containsArray(store, path)) {
@@ -183,7 +184,7 @@ export async function openArray(
             if (shape === undefined) {
                 throw new ValueError("Shape can not be undefined when creating a new array");
             }
-            await initArray(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters);
+            await initArray(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters, nested);
         }
     } else {
         throw new ValueError(`Invalid mode argument: ${mode}`);

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -120,7 +120,8 @@ async function initArrayMetadata(
     order: Order,
     overwrite: boolean,
     chunkStore: null | Store,
-    filters: null | Filter[]
+    filters: null | Filter[],
+    nested: null | boolean
 ) {
     // Guard conditions
     if (overwrite) {
@@ -163,6 +164,7 @@ async function initArrayMetadata(
         order: order,
         compressor: compressor,
         filters: filters,
+        nested: nested,
     };
     const metaKey = pathToPrefix(path) + ARRAY_META_KEY;
     await store.setItem(metaKey, JSON.stringify(metadata));
@@ -184,10 +186,11 @@ export async function initArray(
     order: Order = "C",
     overwrite = false,
     chunkStore: null | Store = null,
-    filters: null | Filter[] = null
+    filters: null | Filter[] = null,
+    nested: null | boolean
 ) {
 
     path = normalizeStoragePath(path);
     await requireParentGroup(store, path, chunkStore, overwrite);
-    await initArrayMetadata(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters);
+    await initArrayMetadata(store, shape, chunks, dtype, path, compressor, fillValue, order, overwrite, chunkStore, filters, nested);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,11 @@ export interface ZarrArrayMetadata {
    * A list of JSON objects providing codec configurations, or `null` if no filters are to be applied. Each codec configuration object MUST contain a `"id"` key identifying the codec to be used.
    */
   filters: null | Filter[];
+
+  /**
+   * A boolean to specify if chunks are stored in a nested directory tree
+   */
+  nested: null | boolean;
 }
 
 export interface ZarrGroupMetadata {


### PR DESCRIPTION
This adds support for nested zarr stores, where the chunks are in nested directories.

Tested locally in the browser with data generated from latest `bioformats2raw` [0.3.0rc1](https://github.com/glencoesoftware/bioformats2raw/releases/tag/v0.3.0rc1) release with and without the `--nested` flag.

