### PR TITLE
Make nodes generic over store(s)

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -422,7 +422,7 @@ export class ZarrArray<Store extends ZarrStore=ZarrStore, ChunkStore extends Zar
     }
   }
 
-  public async getRawChunk(chunkCoords: number[], opts?: GetRawChunkOptions<Store>): Promise<RawArray> {
+  public async getRawChunk(chunkCoords: number[], opts?: GetRawChunkOptions<ChunkStore>): Promise<RawArray> {
     if (chunkCoords.length !== this.shape.length) {
       throw new Error(`Chunk coordinates ${chunkCoords.join(".")} do not correspond to shape ${this.shape}.`);
     }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,4 @@
-import { Store as _Store, ValidStoreType } from "../storage/types";
+import { Store as ZarrStore, ValidStoreType } from "../storage/types";
 
 import { containsGroup, pathToPrefix } from '../storage/index';
 import { normalizeStoragePath, isTotalSlice, arrayEquals1D, byteSwap, byteSwapInplace } from '../util';
@@ -34,11 +34,11 @@ export interface SetOptions {
   }) => void;
 }
 
-export interface GetRawChunkOptions<O> {
-  storeOptions: O;
+export interface GetRawChunkOptions<Store extends ZarrStore> {
+  storeOptions: Parameters<Store['getItem']>[1];
 }
 
-export class ZarrArray<Store extends _Store, ChunkStore extends _Store=Store> {
+export class ZarrArray<Store extends ZarrStore, ChunkStore extends ZarrStore=Store> {
 
   public store: Store;
   public chunkStore: ChunkStore;
@@ -184,12 +184,12 @@ export class ZarrArray<Store extends _Store, ChunkStore extends _Store=Store> {
    * @param cacheAttrs If true (default), user attributes will be cached for attribute read operations.
    * If false, user attributes are reloaded from the store prior to all attribute read operations.
    */
-  public static async create<Store extends _Store, ChunkStore extends _Store=Store>(store: Store, path: null | string = null, readOnly = false, chunkStore: ChunkStore | null = null, cacheMetadata = true, cacheAttrs = true) {
+  public static async create<Store extends ZarrStore, ChunkStore extends ZarrStore=Store>(store: Store, path: null | string = null, readOnly = false, chunkStore: ChunkStore | null = null, cacheMetadata = true, cacheAttrs = true) {
     const metadata = await this.loadMetadataForConstructor(store, path);
     return new ZarrArray(store, path, metadata as ZarrArrayMetadata, readOnly, chunkStore, cacheMetadata, cacheAttrs);
   }
 
-  private static async loadMetadataForConstructor(store: _Store, path: null | string) {
+  private static async loadMetadataForConstructor(store: ZarrStore, path: null | string) {
     try {
       path = normalizeStoragePath(path);
       const keyPrefix = pathToPrefix(path);
@@ -422,7 +422,7 @@ export class ZarrArray<Store extends _Store, ChunkStore extends _Store=Store> {
     }
   }
 
-  public async getRawChunk<O>(chunkCoords: number[], opts?: GetRawChunkOptions<O>): Promise<RawArray> {
+  public async getRawChunk(chunkCoords: number[], opts?: GetRawChunkOptions<Store>): Promise<RawArray> {
     if (chunkCoords.length !== this.shape.length) {
       throw new Error(`Chunk coordinates ${chunkCoords.join(".")} do not correspond to shape ${this.shape}.`);
     }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,7 +11,7 @@ import { BasicIndexer, isContiguousSelection, normalizeIntegerSelection } from '
 import { NestedArray } from "../nestedArray";
 import { RawArray } from "../rawArray";
 import { TypedArray, getTypedArrayCtr } from '../nestedArray/types';
-import { ValueError, PermissionError, BoundsCheckError, ContainsGroupError, isKeyError, HTTPError } from '../errors';
+import { ValueError, PermissionError, BoundsCheckError, ContainsGroupError, isKeyError } from '../errors';
 import { getCodec } from "../compression/registry";
 
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -38,7 +38,7 @@ export interface GetRawChunkOptions<Store extends ZarrStore> {
   storeOptions: Parameters<Store['getItem']>[1];
 }
 
-export class ZarrArray<Store extends ZarrStore, ChunkStore extends ZarrStore=Store> {
+export class ZarrArray<Store extends ZarrStore=ZarrStore, ChunkStore extends ZarrStore=Store> {
 
   public store: Store;
   public chunkStore: ChunkStore;

--- a/src/creation.ts
+++ b/src/creation.ts
@@ -30,7 +30,7 @@ export type CreateArrayOptions<
     dimensionSeparator?: '.' | '/';
 };
 
-export type Normalize<S> = S extends string ? HTTPStore: S extends undefined ? MemoryStore<ValidStoreType> : S extends ZarrStore ? S : never;
+export type Normalize<S> = S extends string ? HTTPStore: S extends undefined ? MemoryStore : S extends ZarrStore ? S : never;
 export function normalizeStoreArgument<S>(store?: S): Normalize<S> {
     if (store === undefined) {
         return new MemoryStore() as Normalize<S>
@@ -67,7 +67,7 @@ export function normalizeStoreArgument<S>(store?: S): Normalize<S> {
  * @param dimensionSeparator if specified, defines an alternate string separator placed between the dimension chunks.
  */
 export async function create<
-    StoreOption extends ZarrStore | string=MemoryStore<ValidStoreType>,
+    StoreOption extends ZarrStore | string=MemoryStore,
     ChunkStoreOption extends ZarrStore=Normalize<StoreOption>,
 >(
     { shape, chunks = true, dtype = "<i4", compressor = null, fillValue = null, order = "C", store, overwrite = false, path, chunkStore, filters, cacheMetadata = true, cacheAttrs = true, readOnly = false, dimensionSeparator }: CreateArrayOptions<StoreOption, ChunkStoreOption>,
@@ -83,7 +83,7 @@ export async function create<
  * Create an empty array.
  */
 export async function empty<
-    StoreOption extends ZarrStore | string=MemoryStore<ValidStoreType>,
+    StoreOption extends ZarrStore | string=MemoryStore,
     ChunkStoreOption extends ZarrStore=Normalize<StoreOption>,
 >(shape: number | number[], opts: Omit<CreateArrayOptions<StoreOption, ChunkStoreOption>, 'shape'> = {}) {
     opts.fillValue = null;
@@ -95,7 +95,7 @@ export async function empty<
  * uninitialized portions of the array.
  */
 export async function zeros<
-    StoreOption extends ZarrStore | string=MemoryStore<ValidStoreType>,
+    StoreOption extends ZarrStore | string=MemoryStore,
     ChunkStoreOption extends ZarrStore=Normalize<StoreOption>,
 >(shape: number | number[], opts: Omit<CreateArrayOptions<StoreOption, ChunkStoreOption>, 'shape'> = {}) {
     opts.fillValue = 0;
@@ -107,7 +107,7 @@ export async function zeros<
  * uninitialized portions of the array.
  */
 export async function ones<
-    StoreOption extends ZarrStore | string=MemoryStore<ValidStoreType>,
+    StoreOption extends ZarrStore | string=MemoryStore,
     ChunkStoreOption extends ZarrStore=Normalize<StoreOption>,
 >(shape: number | number[], opts: Omit<CreateArrayOptions<StoreOption, ChunkStoreOption>, 'shape'> = {}) {
     opts.fillValue = 1;
@@ -119,7 +119,7 @@ export async function ones<
  * uninitialized portions of the array
  */
 export async function full<
-    StoreOption extends ZarrStore | string=MemoryStore<ValidStoreType>,
+    StoreOption extends ZarrStore | string=MemoryStore,
     ChunkStoreOption extends ZarrStore=Normalize<StoreOption>,
 >(shape: number | number[], fillValue: FillType, opts: Omit<CreateArrayOptions<StoreOption, ChunkStoreOption>, 'shape'> = {}) {
     opts.fillValue = fillValue;
@@ -127,7 +127,7 @@ export async function full<
 }
 
 export async function array<
-    StoreOption extends ZarrStore | string=MemoryStore<ValidStoreType>,
+    StoreOption extends ZarrStore | string=MemoryStore,
     ChunkStoreOption extends ZarrStore=Normalize<StoreOption>,
 >(data: Buffer | ArrayBuffer | NestedArray<TypedArray>, opts: Omit<CreateArrayOptions<StoreOption, ChunkStoreOption>, 'shape'> = {}) {
     // TODO: infer chunks?
@@ -155,7 +155,7 @@ export async function array<
 type OpenArrayOptions<StoreOption extends ZarrStore | string, ChunkStoreOption extends ZarrStore>= Partial<CreateArrayOptions<StoreOption, ChunkStoreOption> & { mode: PersistenceMode }>;
 
 export async function openArray<
-    StoreOption extends ZarrStore | string=MemoryStore<ValidStoreType>,
+    StoreOption extends ZarrStore | string=MemoryStore,
     ChunkStoreOption extends ZarrStore=Normalize<StoreOption>,
 >(
     { shape, mode = "a", chunks = true, dtype = "<i4", compressor = null, fillValue = null, order = "C", store: storeOption, overwrite = false, path = null, chunkStore, filters, cacheMetadata = true, cacheAttrs = true, dimensionSeparator }: OpenArrayOptions<StoreOption, ChunkStoreOption> = {},

--- a/src/creation.ts
+++ b/src/creation.ts
@@ -1,5 +1,5 @@
 import { ChunksArgument, DtypeString, CompressorConfig, Order, Filter, FillType, PersistenceMode } from './types';
-import { Store as ZarrStore, ValidStoreType } from './storage/types';
+import { Store as ZarrStore } from './storage/types';
 import { ZarrArray } from './core/index';
 import { MemoryStore } from './storage/memoryStore';
 import { initArray, containsArray, containsGroup } from './storage/index';

--- a/src/creation.ts
+++ b/src/creation.ts
@@ -12,7 +12,7 @@ import { HTTPStore } from './storage/httpStore';
 export type CreateArrayOptions<
     StoreOption extends ZarrStore | string=ZarrStore,
     ChunkStoreOption extends ZarrStore=ZarrStore,
->= {
+> = {
     shape: number | number[];
     chunks?: ChunksArgument;
     dtype?: DtypeString;

--- a/src/hierarchy.ts
+++ b/src/hierarchy.ts
@@ -247,7 +247,7 @@ export class Group<
  *   If `false`, user attributes are reloaded from the store prior to all attribute read operations.
  */
 export async function group<
-    StoreOption extends ZarrStore | string=MemoryStore<ValidStoreType>,
+    StoreOption extends ZarrStore | string=MemoryStore,
     ChunkStore extends ZarrStore=Normalize<StoreOption>,
 >(storeOption?: StoreOption, path: string | null = null, chunkStore?: ChunkStore, overwrite = false, cacheAttrs = true) {
     const store = normalizeStoreArgument(storeOption);
@@ -271,7 +271,7 @@ export async function group<
  *
  */
 export async function openGroup<
-    StoreOption extends ZarrStore | string=MemoryStore<ValidStoreType>,
+    StoreOption extends ZarrStore | string=MemoryStore,
     ChunkStore extends ZarrStore=Normalize<StoreOption>,
 >(storeOption?: StoreOption, path: string | null = null, mode: PersistenceMode = "a", chunkStore?: ChunkStore, cacheAttrs = true) {
     const store = normalizeStoreArgument(storeOption);

--- a/src/storage/memoryStore.ts
+++ b/src/storage/memoryStore.ts
@@ -2,7 +2,7 @@ import { SyncStore, ValidStoreType } from "./types";
 import { createProxy, MutableMappingProxy } from "../mutableMapping";
 import { KeyError } from "../errors";
 
-export class MemoryStore<T extends ValidStoreType> implements SyncStore<T> {
+export class MemoryStore<T extends ValidStoreType=ValidStoreType> implements SyncStore<T> {
     listDir?: undefined;
     rmDir?: undefined;
     getSize?: undefined;


### PR DESCRIPTION
This is mostly a fun TS typing experiment. Since we introduced `getOptions` to #72, `ZarrArray.getRawChunk(key, { storageOptions })`is typed as `any`, regardless of the underlying store. This PR makes `ZarrArray` and `Group` generic over the storage backend, meaning that the `storageOptions` type can be inferred depending on the store.

Infer `storeOptions`:

![image](https://user-images.githubusercontent.com/24403730/123521444-b96eb700-d684-11eb-9d2a-463e7494de25.png)

Infer chunkStore from store:

![image](https://user-images.githubusercontent.com/24403730/123521454-c390b580-d684-11eb-9294-5d2d6cf17bf7.png)

Generic over both stores:

![image](https://user-images.githubusercontent.com/24403730/123521492-ede27300-d684-11eb-87b1-19d5a27f5034.png)


Custom Store:

![image](https://user-images.githubusercontent.com/24403730/123521766-b7a5f300-d686-11eb-96c2-9b5c7f1cde69.png)

![image](https://user-images.githubusercontent.com/24403730/123521778-ca202c80-d686-11eb-808f-fe8996b5af3a.png)

