### PR TITLE
Don't minify internal exports

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -15,6 +15,7 @@ export default [
       entryFileNames: '[name].mjs',
       chunkFileNames: '[name].mjs',
       manualChunks: { core: ['src/zarr-core.ts'] },
+      minifyInternalExports: false,
       sourcemap: true,
     },
     {
@@ -23,6 +24,7 @@ export default [
       entryFileNames: '[name].min.mjs',
       chunkFileNames: '[name].min.mjs',
       manualChunks: { core: ['src/zarr-core.ts'] },
+      minifyInternalExports: false,
       sourcemap: true,
       plugins: [terser()]
     },


### PR DESCRIPTION
The use of `manualChunks` in #80 broke importing modules from `zarr/core` in `0.5.0` since the export names are minified e.g.:

```javascript
// core.mjs
export { BoundsCheckError as B, /* ... */ };
``` 

```javascript
// zarr.mjs
import { B as BoundsCheckError, /* ... */ } from './core.mjs';
```

so,

```javascript
import { BoundsCheckError } from './core.mjs'; // export doesn't exist!
```

This PR prevents the minification of the named exports. I'll cut a patch release once this is merged.