### PR TITLE
Use URL-based path resolution in `HTTPStore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Release 0.5.2
 **Date:** Unreleased
 
+* Use `URL`-based path resolution in `HTTPStore`. Allows for forwarding of `URL.searchParams` if specified.
+
 ## Release 0.5.1
 **Date:** 2021-07-19
 

--- a/src/storage/httpStore.ts
+++ b/src/storage/httpStore.ts
@@ -15,7 +15,7 @@ interface HTTPStoreOptions {
     supportedMethods?: HTTPMethod[];
 }
 
-export class HTTPStore<UrlRoot extends string | URL> implements AsyncStore<ArrayBuffer> {
+export class HTTPStore<UrlRoot extends string | URL=string> implements AsyncStore<ArrayBuffer> {
     listDir?: undefined;
     rmDir?: undefined;
     getSize?: undefined;

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,6 +40,7 @@ export function normalizeStoragePath(path: string | String | null): string {
 
     // convert backslash to forward slash
     path = path.replace(/\\/g, "/");
+
     // ensure no leading slash
     while (path.length > 0 && path[0] === '/') {
         path = path.slice(1);
@@ -192,21 +193,21 @@ export function getStrides(shape: number[]): number[] {
     return strides;
 }
 
-/**
- * Preserves (double) slashes earlier in the path, so this works better
- * for URLs. From https://stackoverflow.com/a/46427607/4178400
- * @param args parts of a path or URL to join.
- */
-export function joinUrlParts(...args: string[]) {
-    return args.map((part, i) => {
-        if (i === 0) {
-          return part.trim().replace(/[\/]*$/g, '');
-        } else {
-          return part.trim().replace(/(^[\/]*|[\/]*$)/g, '');
-        }
-      }).filter(x=>x.length).join('/');
+export function createUrlResolver(url: string | URL): (path?: string) => string {
+    const base = typeof url === 'string' ? new URL(url) : url;
+    if (!base.pathname.endsWith('/')) {
+        // ensure trailing slash
+        base.pathname += '/';
+    }
+    return (path?: string) => {
+        if (!path) return base.href;
+        // add trailing slash to resolve path relative to base _directory_
+        const fileUrl = new URL(path, base);
+        // copy search params to new URL
+        fileUrl.search = base.search;
+        return fileUrl.href;
+    }
 }
-
 
 /**
  * Swaps byte order in-place for a given TypedArray.

--- a/src/util.ts
+++ b/src/util.ts
@@ -193,20 +193,16 @@ export function getStrides(shape: number[]): number[] {
     return strides;
 }
 
-export function createUrlResolver(url: string | URL): (path?: string) => string {
-    const base = typeof url === 'string' ? new URL(url) : url;
+export function resolveUrl(root: string | URL, path: string): string {
+    const base = typeof root === 'string' ? new URL(root) : root;
     if (!base.pathname.endsWith('/')) {
-        // ensure trailing slash
+        // ensure trailing slash so that base is resolved as _directory_
         base.pathname += '/';
     }
-    return (path?: string) => {
-        if (!path) return base.href;
-        // add trailing slash to resolve path relative to base _directory_
-        const fileUrl = new URL(path, base);
-        // copy search params to new URL
-        fileUrl.search = base.search;
-        return fileUrl.href;
-    }
+    const resolved = new URL(path, base);
+    // copy search params to new URL
+    resolved.search = base.search;
+    return resolved.href;
 }
 
 /**

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -77,16 +77,21 @@ describe("ArrayEquals1D works", () => {
 });
 
 describe("URL joining works", () => {
-    test.each<[[string, string | undefined], string]>([
+    test.each<[[string | URL, string | undefined], string]>([
         [["https://example.com", "bla"], "https://example.com/bla"],
         [["https://example.com/my-store", "arr.zarr"], "https://example.com/my-store/arr.zarr"],
         [["https://example.com/", "arr.zarr"], "https://example.com/arr.zarr"],
         [["https://example.com/?hello=world", "arr.zarr"], "https://example.com/arr.zarr?hello=world"],
         [["https://example.com?hello=world", "arr.zarr"], "https://example.com/arr.zarr?hello=world"],
-        [["https://example.com/arr.zarr", undefined], "https://example.com/arr.zarr/"],
         [["https://example.com/arr.zarr/my-store/", ".zarray"], "https://example.com/arr.zarr/my-store/.zarray"],
-    ])("joins parts as expected: output %s, expected %p", ([root, path]: [string, string], expected: string) => {
-        expect(util.createUrlResolver(root)(path)).toEqual(expected);
+        [[(() => {
+            const root = new URL("https://example.com/arr.zarr/my-store/");
+            root.searchParams.set("hello", "world");
+            root.searchParams.set("foo", "bar");
+            return root;
+        })(), ".zarray"], "https://example.com/arr.zarr/my-store/.zarray?hello=world&foo=bar"],
+    ])("joins parts as expected: output %s, expected %p", ([root, path]: [string | URL, string], expected: string) => {
+        expect(util.resolveUrl(root, path)).toEqual(expected);
     });
 });
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -79,11 +79,12 @@ describe("ArrayEquals1D works", () => {
 describe("URL resolution works", () => {
     test.each<[[string | URL, string], string]>([
         [["https://example.com", "bla"], "https://example.com/bla"],
-        [["https://example.com/my-store", "arr.zarr"], "https://example.com/my-store/arr.zarr"],
-        [["https://example.com/", "arr.zarr"], "https://example.com/arr.zarr"],
-        [["https://example.com/?hello=world", "arr.zarr"], "https://example.com/arr.zarr?hello=world"],
-        [["https://example.com?hello=world", "arr.zarr"], "https://example.com/arr.zarr?hello=world"],
-        [["https://example.com/arr.zarr/my-store/", ".zarray"], "https://example.com/arr.zarr/my-store/.zarray"],
+        [["https://example.com/my-store", "data.zarr"], "https://example.com/my-store/data.zarr"],
+        [["https://example.com/", "data.zarr"], "https://example.com/data.zarr"],
+        [["https://example.com/?hello=world", "data.zarr"], "https://example.com/data.zarr?hello=world"],
+        [["https://example.com?hello=world", "data.zarr"], "https://example.com/data.zarr?hello=world"],
+        [["https://example.com/data.zarr/nested/arr/", ".zarray"], "https://example.com/data.zarr/nested/arr/.zarray"],
+        [["https://example.com/data.zarr/nested/arr", ".zarray"], "https://example.com/data.zarr/nested/arr/.zarray"],
         [["https://example.com/data.zarr/nested/group", "../.zgroup"], "https://example.com/data.zarr/nested/.zgroup"],
         [[(() => {
             const root = new URL("https://example.com/arr.zarr/my-store/");
@@ -91,6 +92,14 @@ describe("URL resolution works", () => {
             root.searchParams.set("foo", "bar");
             return root;
         })(), ".zarray"], "https://example.com/arr.zarr/my-store/.zarray?hello=world&foo=bar"],
+        [[(() => {
+            const root = new URL("https://example.com/arr.zarr/my-store/");
+            root.username = "foo";
+            root.password = "bar";
+            root.searchParams.set("hello", "world");
+            root.searchParams.set("foo", "bar");
+            return root;
+        })(), ".zarray"], "https://foo:bar@example.com/arr.zarr/my-store/.zarray?hello=world&foo=bar"],
     ])("joins parts as expected: output %s, expected %p", ([root, path]: [string | URL, string], expected: string) => {
         expect(util.resolveUrl(root, path)).toEqual(expected);
     });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -84,6 +84,7 @@ describe("URL resolution works", () => {
         [["https://example.com/?hello=world", "arr.zarr"], "https://example.com/arr.zarr?hello=world"],
         [["https://example.com?hello=world", "arr.zarr"], "https://example.com/arr.zarr?hello=world"],
         [["https://example.com/arr.zarr/my-store/", ".zarray"], "https://example.com/arr.zarr/my-store/.zarray"],
+        [["https://example.com/data.zarr/nested/group", "../.zgroup"], "https://example.com/data.zarr/nested/.zgroup"],
         [[(() => {
             const root = new URL("https://example.com/arr.zarr/my-store/");
             root.searchParams.set("hello", "world");

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -77,14 +77,16 @@ describe("ArrayEquals1D works", () => {
 });
 
 describe("URL joining works", () => {
-    test.each([
+    test.each<[[string, string | undefined], string]>([
         [["https://example.com", "bla"], "https://example.com/bla"],
         [["https://example.com/my-store", "arr.zarr"], "https://example.com/my-store/arr.zarr"],
         [["https://example.com/", "arr.zarr"], "https://example.com/arr.zarr"],
-        [["https://example.com/", "", "arr.zarr"], "https://example.com/arr.zarr"],
-        // eslint-disable-next-line @typescript-eslint/ban-types
-    ])("joins parts as expected: output %s, expected %p", (parts: string[] | String, expected: string) => {
-        expect(util.joinUrlParts(...parts)).toEqual(expected);
+        [["https://example.com/?hello=world", "arr.zarr"], "https://example.com/arr.zarr?hello=world"],
+        [["https://example.com?hello=world", "arr.zarr"], "https://example.com/arr.zarr?hello=world"],
+        [["https://example.com/arr.zarr", undefined], "https://example.com/arr.zarr/"],
+        [["https://example.com/arr.zarr/my-store/", ".zarray"], "https://example.com/arr.zarr/my-store/.zarray"],
+    ])("joins parts as expected: output %s, expected %p", ([root, path]: [string, string], expected: string) => {
+        expect(util.createUrlResolver(root)(path)).toEqual(expected);
     });
 });
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -76,8 +76,8 @@ describe("ArrayEquals1D works", () => {
     });
 });
 
-describe("URL joining works", () => {
-    test.each<[[string | URL, string | undefined], string]>([
+describe("URL resolution works", () => {
+    test.each<[[string | URL, string], string]>([
         [["https://example.com", "bla"], "https://example.com/bla"],
         [["https://example.com/my-store", "arr.zarr"], "https://example.com/my-store/arr.zarr"],
         [["https://example.com/", "arr.zarr"], "https://example.com/arr.zarr"],


### PR DESCRIPTION
In #42 we migrated from `URL`-based path resolution to a more simple string concatenation. This PR fixes the same issue as #42 but reverts back to using `URL`. 

It also adds a feature requested for forwarding search query params when resolving the new URL, so that an `HTTPStore` can be instantiated as follows:

```javascript
const store = new HTTPStore("https://example.com/data.zarr?hello=world");
store.getItem('.zarray') // requests "https://example.com/data.zarr/.zarray?hello=world"
```

Generally I'd be in favor of migrating the type of `HTTPStore.url` to `URL`, but since it is a public field I have set it to a generic (with default to `string`). 

cc: @ilan-gold 