### PR TITLE
fix: change comparsion for empty selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release 0.5.2
 **Date:** Unreleased
 
+* Fix unreachable code paths due to always `false` `Array === []` comparison when checking empty selection.
 * Use `URL`-based path resolution in `HTTPStore`. Allows for forwarding of `URL.searchParams` if specified.
 
 ## Release 0.5.1

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -155,7 +155,7 @@ export class ZarrArray {
 
 
   private get _chunkDataShape() {
-    if (this.shape === []) {
+    if (this.shape.length === 0) {
       return [1];
     } else {
       const s = [];
@@ -289,7 +289,7 @@ export class ZarrArray {
     }
 
     // Check fields (TODO?)
-    if (this.shape === []) {
+    if (this.shape.length === 0) {
       throw new Error("Shape [] indexing is not supported yet");
     } else {
       return this.getBasicSelectionND(selection, asRaw, concurrencyLimit, progressCallback);
@@ -527,7 +527,7 @@ export class ZarrArray {
       await this.reloadMetadata();
     }
 
-    if (this.shape === []) {
+    if (this.shape.length === 0) {
       throw new Error("Shape [] indexing is not supported yet");
     } else {
       await this.setBasicSelectionND(selection, value, concurrencyLimit, progressCallback);
@@ -541,7 +541,7 @@ export class ZarrArray {
 
   private getChunkValue(proj: ChunkProjection, indexer: Indexer, value: number | NestedArray<TypedArray>, selectionShape: number[]): number | NestedArray<TypedArray> {
     let chunkValue: number | NestedArray<TypedArray>;
-    if (selectionShape === []) {
+    if (selectionShape.length === 0) {
       chunkValue = value;
     } else if (typeof value === "number") {
       chunkValue = value;
@@ -569,7 +569,7 @@ export class ZarrArray {
     const selectionShape = indexer.shape;
 
     // Check value shape
-    if (selectionShape === []) {
+    if (selectionShape.length === 0) {
       // Setting a single value
     } else if (typeof value === "number") {
       // Setting a scalar value


### PR DESCRIPTION
I was using esbuild to bundle zarr.js in project and it identified some impossible code paths
due to the comparison used for an empty selection:

```bash
❯ esbuild --bundle src/zarr-core.ts --outfile=out.js
 > src/core/index.ts:158:19: warning: Comparison using the "===" operator here is always false
    158 │     if (this.shape === []) {
        ╵                    ~~~

 > src/core/index.ts:292:19: warning: Comparison using the "===" operator here is always false
    292 │     if (this.shape === []) {
        ╵                    ~~~

 > src/core/index.ts:530:19: warning: Comparison using the "===" operator here is always false
    530 │     if (this.shape === []) {
        ╵                    ~~~

 > src/core/index.ts:544:23: warning: Comparison using the "===" operator here is always false
    544 │     if (selectionShape === []) {
        ╵                        ~~~

 > src/core/index.ts:572:23: warning: Comparison using the "===" operator here is always false
    572 │     if (selectionShape === []) {
        ╵                        ~~~

5 warnings

  out.js  90.4kb

⚡ Done in 13ms
```

This PR changes the empty selection comparison to be `shape.length === 0`.
