### PR TITLE
chore: upgrade numcodecs

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    [ "@babel/preset-env", { "targets": { "esmodules": true } }],
+    "@babel/preset-typescript"
+  ]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,6 @@ function baseConfig() {
   }
 }
 
-
 module.exports = {
   ...baseConfig(),
   coverageThreshold: {
@@ -21,5 +20,7 @@ module.exports = {
       statements: 55
     }
   },
-  collectCoverageFrom: ["src/**/*.ts"]
+  collectCoverageFrom: ["src/**/*.ts"],
+  // nucodecs is ESM-only, so we need to include it in our transforms
+  transformIgnorePatterns: [`/node_modules/(?!numcodecs)`]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2420,9 +2420,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001194",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz",
-      "integrity": "sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA==",
+      "version": "1.0.30001261",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz",
+      "integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==",
       "dev": true
     },
     "capture-exit": {
@@ -5704,9 +5704,9 @@
       }
     },
     "numcodecs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.1.tgz",
-      "integrity": "sha512-0ktyCFBEno8mLuC/bTfJk8LjDy7GvQOa9Ern2zsAhM8sU5uiUGZPyXVzD7kEtx90fRPzohodg1fd82/xzAupLA=="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ=="
     },
     "nwsapi": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -64,19 +64,6 @@
     "prepublishOnly": "npm run build && cp -r ./dist/* .",
     "postpublish": "git clean -fd"
   },
-  "babel": {
-    "presets": [
-      [
-        "@babel/preset-env",
-        {
-          "targets": {
-            "esmodules": true
-          }
-        }
-      ],
-      "@babel/preset-typescript"
-    ]
-  },
   "devDependencies": {
     "@babel/preset-env": "^7.13.9",
     "@babel/preset-typescript": "^7.13.0",
@@ -102,7 +89,7 @@
     "typescript": "^4.2.2"
   },
   "dependencies": {
-    "numcodecs": "^0.2.1",
+    "numcodecs": "^0.2.2",
     "p-queue": "6.2.0"
   }
 }


### PR DESCRIPTION
I am bumping numcodecs because it is a pure ESM module now. As a result, I had to reconfigure our transforms for jest to include `numcodecs`. Apparently `transformIgnorePatterns` is ignored when `"babel"` is included in package.json or `.babelrc` is used... only `babel.config.js`. This was very frustrating to find, but has been resolved: https://github.com/facebook/jest/issues/10256