### PR TITLE
Add  `|b1` dtype

### DIFF
--- a/src/nestedArray/types.ts
+++ b/src/nestedArray/types.ts
@@ -38,6 +38,7 @@ export type TypedArrayConstructor<T extends TypedArray> = {
 
 const DTYPE_TYPEDARRAY_MAPPING: { [A in DtypeString]: TypedArrayConstructor<TypedArray> } = {
   '|b': Int8Array,
+  '|b1': Uint8Array,
   '|B': Uint8Array,
   '|u1': Uint8Array,
   '|i1': Int8Array,

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export type DtypeString =
   | '|u1'
   | '|i1'
   | '|b'
+  | '|b1'
   | '|B'
   | '<u1'
   | '<i1'


### PR DESCRIPTION
Adds support for the `|b1` dtype.