### PR TITLE
Support i8 and u8 dtypes

### DIFF
--- a/src/nestedArray/index.ts
+++ b/src/nestedArray/index.ts
@@ -118,7 +118,13 @@ export class NestedArray<T extends TypedArray> {
 export function rangeTypedArray<T extends TypedArray>(shape: number[], tContructor: TypedArrayConstructor<T>) {
     const size = shape.reduce((x, y) => x * y, 1);
     const data = new tContructor(size);
-    data.set([...Array(size).keys()]); // Sets range 0,1,2,3,4,5
+    let values: any[] = [];
+    if (data[Symbol.toStringTag] === 'BigUint64Array' || data[Symbol.toStringTag] === 'BigInt64Array') {
+        values = [...Array(size).keys()].map(BigInt);      
+    } else {
+        values = [...Array(size).keys()];
+    }
+    data.set(values);
     return data;
 }
 

--- a/src/nestedArray/types.ts
+++ b/src/nestedArray/types.ts
@@ -25,6 +25,8 @@ export type TypedArray =
   | Int32Array
   | Float32Array
   | Float64Array
+  | BigUint64Array
+  | BigInt64Array
   | InstanceType<Float16ArrayConstructor>;
 
 export type TypedArrayConstructor<T extends TypedArray> = {
@@ -53,6 +55,8 @@ const DTYPE_TYPEDARRAY_MAPPING: { [A in DtypeString]: TypedArrayConstructor<Type
   '<f4': Float32Array,
   '<f2': Float16Array,
   '<f8': Float64Array,
+  '<u8': BigUint64Array,
+  '<i8': BigInt64Array,
   '>b': Int8Array,
   '>B': Uint8Array,
   '>u1': Uint8Array,
@@ -63,7 +67,10 @@ const DTYPE_TYPEDARRAY_MAPPING: { [A in DtypeString]: TypedArrayConstructor<Type
   '>i4': Int32Array,
   '>f4': Float32Array,
   '>f2': Float16Array,
-  '>f8': Float64Array
+  '>f8': Float64Array,
+  '>u8': BigUint64Array,
+  '>i8': BigInt64Array
+
 };
 
 export function getTypedArrayCtr(dtype: DtypeString) {
@@ -100,5 +107,7 @@ export function getTypedArrayDtypeString(t: TypedArray): DtypeString {
   if (t instanceof Int32Array) return '<i4';
   if (t instanceof Float32Array) return '<f4';
   if (t instanceof Float64Array) return '<f8';
+  if (t instanceof BigUint64Array) return '<u8';
+  if (t instanceof BigInt64Array) return '<i8';
   throw new ValueError('Mapping for TypedArray to Dtypestring not known');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,8 @@ export type DtypeString =
   | '<f2'
   | '<f4'
   | '<f8'
+  | '<u8'
+  | '<i8'
   | '>u1'
   | '>i1'
   | '>b'
@@ -42,7 +44,9 @@ export type DtypeString =
   | '>i4'
   | '>f4'
   | '>f2'
-  | '>f8';
+  | '>f8'
+  | '>u8'
+  | '>i8';
 
 /**
  * User interface for chunking.

--- a/test/core/zarrArray.test.ts
+++ b/test/core/zarrArray.test.ts
@@ -69,7 +69,7 @@ describe("ZarrArray Creation", () => {
 
     it("errors for unsupported/invalid dtype", async () => {
         const store = new ObjectStore<Buffer>();
-        await initArray(store, 100, 5, '<i8' as any);
+        await initArray(store, 100, 5, '<i64' as any);
         const z = await ZarrArray.create(store);
         await expect(z.get(null)).rejects.toBeTruthy();
     });

--- a/test/nestedArray/ops.creation.test.ts
+++ b/test/nestedArray/ops.creation.test.ts
@@ -170,6 +170,28 @@ describe('NestedArray creation', () => {
           [Uint32Array.from([8, 9, 10, 11]), Uint32Array.from([12, 13, 14, 15])]
         ]
       ]
+    },
+    {
+      name: '4d_1x2x2x4_u8',
+      shape: [1, 2, 2, 4],
+      constr: BigUint64Array,
+      expected: [
+        [
+          [BigUint64Array.from([0n, 1n, 2n, 3n]), BigUint64Array.from([4n, 5n, 6n, 7n])],
+          [BigUint64Array.from([8n, 9n, 10n, 11n]), BigUint64Array.from([12n, 13n, 14n, 15n])]
+        ]
+      ]
+    },
+    {
+      name: '4d_1x2x2x4_i8',
+      shape: [1, 2, 2, 4],
+      constr: BigInt64Array,
+      expected: [
+        [
+          [BigInt64Array.from([0n, 1n, 2n, 3n]), BigInt64Array.from([4n, 5n, 6n, 7n])],
+          [BigInt64Array.from([8n, 9n, 10n, 11n]), BigInt64Array.from([12n, 13n, 14n, 15n])]
+        ]
+      ]
     }
   ];
 


### PR DESCRIPTION
Regarding [this](https://github.com/gzuidhof/zarr.js/issues/85) ticket, the dtypes i8 and u8 are now supported. 
 