### PR TITLE
fix(error): Fix error passthrough in queued tasks

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -348,16 +348,16 @@ export class ZarrArray<StoreGetOptions = any> {
       for (const _ of indexer.iter()) queueSize += 1;
       progressCallback({ progress: 0, queueSize: queueSize });
       for (const proj of indexer.iter()) {
-        allTasks.push((async () => {
-          await queue.add(() => this.chunkGetItem(proj.chunkCoords, proj.chunkSelection, out, proj.outSelection, indexer.dropAxes, storeOptions));
+        allTasks.push(queue.add(async () => {
+          await this.chunkGetItem(proj.chunkCoords, proj.chunkSelection, out, proj.outSelection, indexer.dropAxes, storeOptions);
           progress += 1;
           progressCallback({ progress: progress, queueSize: queueSize });
-        })());
+        }));
       }
 
     } else {
       for (const proj of indexer.iter()) {
-        allTasks.push(queue.add(async () => this.chunkGetItem(proj.chunkCoords, proj.chunkSelection, out, proj.outSelection, indexer.dropAxes, storeOptions)));
+        allTasks.push(queue.add(() => this.chunkGetItem(proj.chunkCoords, proj.chunkSelection, out, proj.outSelection, indexer.dropAxes, storeOptions)));
       }
     }
 
@@ -607,11 +607,11 @@ export class ZarrArray<StoreGetOptions = any> {
       progressCallback({ progress: 0, queueSize: queueSize });
       for (const proj of indexer.iter()) {
         const chunkValue = this.getChunkValue(proj, indexer, value, selectionShape);
-        allTasks.push((async () => {
-          await queue.add(() => this.chunkSetItem(proj.chunkCoords, proj.chunkSelection, chunkValue));
+        allTasks.push(queue.add(async () => {
+          await this.chunkSetItem(proj.chunkCoords, proj.chunkSelection, chunkValue);
           progress += 1;
           progressCallback({ progress: progress, queueSize: queueSize });
-        })());
+        }));
       }
 
     } else {


### PR DESCRIPTION
fixes #140

Errors being thrown by `chunkGetItem` (and underlying storage requests) are uncaught.

The use of the PQueue class will both emit an `error` event and throw if awaiting the Promise returned by the `queue.add` method.

To prevent this issue, I created an array of `queue.add` promises, and await for all those promises instead of using `queue.onIdle()`.

Using the error event will still be considered as uncaught errors since nothing is awaiting the queue.add promises.