### PR TITLE
add missing type exports, prevent moving dist files to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,32 +10,34 @@
     "async"
   ],
   "files": [
-    "lib/*",
-    "types/*",
-    "core.mjs",
-    "core.mjs.map",
-    "zarr.mjs",
-    "zarr.mjs.map",
-    "zarr.cjs",
-    "zarr.cjs.map",
-    "zarr.umd.js",
-    "zarr.umd.js.map"
+    "./dist/*"
   ],
   "sideEffects": [
-    "./zarr.mjs"
+    "./dist/zarr.mjs"
   ],
-  "main": "zarr.cjs",
-  "module": "zarr.mjs",
-  "umd:main": "zarr.umd.js",
-  "typings": "types/zarr.d.ts",
+  "main": "./dist/zarr.cjs",
+  "module": "./dist/zarr.mjs",
+  "umd:main": "./dist/zarr.umd.js",
+  "typings": "./dist/types/zarr.d.ts",
   "exports": {
     ".": {
-      "umd": "./zarr.umd.js",
-      "import": "./zarr.mjs",
-      "require": "./zarr.cjs"
+      "umd": "./dist/zarr.umd.js",
+      "import": "./dist/zarr.mjs",
+      "require": "./dist/zarr.cjs",
+      "types": "./dist/types/zarr.d.ts"
     },
     "./core": {
-      "import": "./core.mjs"
+      "import": "./dist/core.mjs",
+      "types": "./dist/types/core/index.d.ts"
+    },
+    "./types": {
+      "types": "./dist/types/types.d.ts"
+    },
+    "./core/types": {
+      "types": "./dist/types/core/types.d.ts"
+    },
+    "./storage/types": {
+      "types": "./dist/types/storage/types.d.ts"
     }
   },
   "author": "Guido Zuidhof <me@guido.io>",
@@ -61,7 +63,6 @@
     "test:prod": "npm run lint && npm run test -- --no-cache && npm run test:browser --no-cache",
     "generate-typedocs": "typedoc --out docs/typedocs --theme minimal --readme none src",
     "report-coverage": "cat ./coverage/lcov.info | coveralls",
-    "prepublishOnly": "npm run build && cp -r ./dist/* .",
     "postpublish": "git clean -fd"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "async"
   ],
   "files": [
-    "./dist/*",
-    "./dist/types/**"
+    "./dist/**"
   ],
   "sideEffects": [
     "./dist/zarr.mjs"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "async"
   ],
   "files": [
-    "./dist/*"
+    "./dist/*",
+    "./dist/types/**"
   ],
   "sideEffects": [
     "./dist/zarr.mjs"
@@ -62,8 +63,7 @@
     "test:watch": "jest --coverage --watch",
     "test:prod": "npm run lint && npm run test -- --no-cache && npm run test:browser --no-cache",
     "generate-typedocs": "typedoc --out docs/typedocs --theme minimal --readme none src",
-    "report-coverage": "cat ./coverage/lcov.info | coveralls",
-    "postpublish": "git clean -fd"
+    "report-coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.6",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "test:watch": "jest --coverage --watch",
     "test:prod": "npm run lint && npm run test -- --no-cache && npm run test:browser --no-cache",
     "generate-typedocs": "typedoc --out docs/typedocs --theme minimal --readme none src",
-    "report-coverage": "cat ./coverage/lcov.info | coveralls"
+    "report-coverage": "cat ./coverage/lcov.info | coveralls",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.6",


### PR DESCRIPTION
- some types are not exported, it is very useful to let users access public API types so they don't have to re-define type of objects passed to the zarr.js api.
- keeps build files in `dist/` instead of moving them to the root dir, moving them breaks development workflow when using `npm link && npm run start` and `npm run link zarr` in another project to use the current dev version of zarr.
- remove hooks to copy and git clean before / after build