### PR TITLE
Propagated HTTP errors in HTTPStore containsItem function

### DIFF
--- a/src/storage/httpStore.ts
+++ b/src/storage/httpStore.ts
@@ -76,6 +76,9 @@ export class HTTPStore<UrlRoot extends string | URL=string> implements AsyncStor
         // Just check headers if HEAD method supported
         const method = this.supportedMethods.has(HTTPMethod.HEAD) ? HTTPMethod.HEAD : HTTPMethod.GET;
         const value = await fetch(url, { ...this.fetchOptions, method });
+        if (value.status !== 200 && value.status !== 404) {
+            throw new HTTPError(String(value.status));
+        }
         return value.status === 200;
     }
 }

--- a/test/globalSetup.js
+++ b/test/globalSetup.js
@@ -3,6 +3,9 @@ const express = require("express");
 
 const app = express();
 app.use(express.static("fixtures", { dotfiles: 'allow' }));
+app.use('/forbidden', function (_req, res) {
+    return res.status(403).end();
+});
 const server = app.listen(3000);
 
 module.exports = async () => {

--- a/test/storage/httpStore.test.ts
+++ b/test/storage/httpStore.test.ts
@@ -1,9 +1,10 @@
 (global as any).fetch = require('node-fetch');
 
+import { HTTPError } from "../../src/errors";
 import { HTTPStore } from "../../src/storage/httpStore";
 import { openArray } from "../../src/creation";
 
-describe("Test MemoryStore", () => {
+describe("Test HTTPStore", () => {
 
     const simpleFixtureStoreLE = new HTTPStore("http://localhost:3000/simple_LE.zarr");
     it("Can open simple fixture", async () => {
@@ -59,5 +60,10 @@ describe("Test MemoryStore", () => {
     it("Can open by path", async () => {
         const z = await openArray({ store: baseUrlStore, path: "simple_LE.zarr" });
         expect(z.shape).toEqual([8, 8]);
+    });
+
+    const forbiddenStore = new HTTPStore("http://localhost:3000/forbidden");
+    it("Propagates HTTP server error", async () => {
+        await expect(openArray({ store: forbiddenStore })).rejects.toThrowError(HTTPError);
     });
 });


### PR DESCRIPTION
Hello,

I'm working on a prototype using zarr.js and an authenticated backend. It would be very useful to be able to distinguish between 200, 404 and "something else" HTTP statuses inside the `containsItem()` function of the `HTTPStore`, so that one can catch the `HTTPError` and display a proper error message to the user.

I see that the `getItem()` function already considers these 3 cases, so I think that the same logic could be applied to `containsItem()`.